### PR TITLE
Adding `docs` workflow to GitHub actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ jobs:
             group: docs
             cancel-in-progress: true
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
               with:
                 python-version: 3.8.13
             - name: "Upgrade pip"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,11 +19,13 @@ jobs:
               run: pip install -r docs/requirements.txt
             - name: "Run sphinx"
               run: sphinx-build -b html docs/source docs/_build/
-            # - name: "Deploy"
-            #   uses: peaceiris/actions-gh-pages@v3
-            #   if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs') }}
-            #   with:
-            #         publish_branch: gh-pages
-            #         github_token: ${{ secrets.GITHUB_TOKEN }}
-            #         publish_dir: docs/_build/html/
-            #         force_orphan: true
+            # Note that we're adding deployment for dev branch here.
+            # In the future, we may want to add a separate workflow for dev branch.
+            - name: "Deploy"
+              uses: peaceiris/actions-gh-pages@v3
+              if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs' || github.ref == 'refs/heads/dev') }}
+              with:
+                    publish_branch: gh-pages
+                    github_token: ${{ secrets.GITHUB_TOKEN }}
+                    publish_dir: docs/_build/html/
+                    force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,8 @@ jobs:
             - uses: actions/setup-python@v2
               with:
                 python-version: 3.8.13
-            # - uses: nikeee/setup-pandoc@v1
             - name: "Upgrade pip"
               run: pip install --upgrade pip
-            # - name: "Install dependencies"
-            #  run: pip install -r requirements/requirements.txt
             - name: "Install docs requirements"
               run: pip install -r docs/requirements.txt
             - name: "Run sphinx"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
             - name: "Install docs requirements"
               run: pip install -r docs/requirements.txt
             - name: "Run sphinx"
-              run: sphinx-build -b html docs/ docs/_build/
+              run: sphinx-build -b html docs/source docs/_build/
             # - name: "Deploy"
             #   uses: peaceiris/actions-gh-pages@v3
             #   if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+on: [push, pull_request, workflow_dispatch]
+permissions:
+    contents: write
+jobs:
+    docs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v2
+              with:
+                python-version: 3.8.13
+            # - uses: nikeee/setup-pandoc@v1
+            - name: "Upgrade pip"
+              run: pip install --upgrade pip
+            # - name: "Install dependencies"
+            #  run: pip install -r requirements/requirements.txt
+            - name: "Install docs requirements"
+              run: pip install -r docs/requirements.txt
+            - name: "Run sphinx"
+              run: sphinx-build -b html docs/ docs/_build/
+            # - name: "Deploy"
+            #   uses: peaceiris/actions-gh-pages@v3
+            #   if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs') }}
+            #   with:
+            #         publish_branch: gh-pages
+            #         github_token: ${{ secrets.GITHUB_TOKEN }}
+            #         publish_dir: docs/_build/html/
+            #         force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
               uses: peaceiris/actions-gh-pages@v3
               if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs' || github.ref == 'refs/heads/dev') }}
               with:
-                    publish_branch: gh-pages
-                    github_token: ${{ secrets.GITHUB_TOKEN }}
-                    publish_dir: docs/_build/html/
-                    force_orphan: true
+                publish_branch: gh-pages
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                publish_dir: docs/_build/html/
+                force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ permissions:
 jobs:
     docs:
         runs-on: ubuntu-latest
+        concurrency:
+            group: docs
+            cancel-in-progress: true
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v2


### PR DESCRIPTION
This PR adds in the `docs` workflow, which checks out the repository, sets up Python, installs documentation requirements, runs sphinx-build, and then finally publishes the resulting `html` directory to the `gh-pages` branch (which can be published to GitHub Pages if we want)

Closes #23 