### PR TITLE
Remove restriction on displaying shapes with multiple Seshat IDs

### DIFF
--- a/cliopatria/map_functions.py
+++ b/cliopatria/map_functions.py
@@ -33,8 +33,6 @@ def create_map(selected_year, gdf, map_output, components=False):
     else:
         # Only shapes where the "MemberOf" column is not populated (i.e., the shape is not a member of another shape, it is a top-level shape itself)
         filtered_gdf = filtered_gdf[(filtered_gdf['MemberOf'].isnull()) | (filtered_gdf['MemberOf'] == '')]
-        # Also filter out "Personal Union" composites where the SeshatId includes a semicolon to avoid overlaps
-        filtered_gdf = filtered_gdf[~filtered_gdf['SeshatID'].str.contains(';')]
 
     # Transform the CRS of the GeoDataFrame to WGS84 (EPSG:4326)
     filtered_gdf = filtered_gdf.to_crs(epsg=4326)

--- a/seshat/apps/core/static/core/js/map_functions.js
+++ b/seshat/apps/core/static/core/js/map_functions.js
@@ -401,7 +401,6 @@ function longAbsentPresentVarName(var_name){
 
 function shouldDisplayComponent(displayComponent, shape) {
     if (displayComponent == 'polities'
-        && shape.seshat_id.includes(';') === false
         && (shape.member_of === null || shape.member_of === '')) {
         return true;
     } else if (displayComponent == 'components'

--- a/seshat/apps/core/templates/core/world_map.html
+++ b/seshat/apps/core/templates/core/world_map.html
@@ -686,6 +686,25 @@
                                             <td><a href="/core/polity/${polityId}" target="_blank">${longName} (${shape.seshat_id})</a></td>
                                         </tr>
                                     `;
+                                } else if (shape.seshat_id.includes(';')) {
+                                    var polityIds = shape.seshat_id.split(';');
+                                    var polityLinks = '';
+                                    for (var i = 0; i < polityIds.length; i++) {
+                                        if (polityIds[i] in seshat_id_page_id) {
+                                            var polityId = seshat_id_page_id[polityIds[i]]['id'];
+                                            longName = seshat_id_page_id[polityIds[i]]['long_name'];
+                                            if (longName == ''){
+                                                longName = '[Page empty]'
+                                            }
+                                            polityLinks = polityLinks + `<a href="/core/polity/${polityId}" target="_blank">${longName} (${polityIds[i]})</a><br>`;
+                                        }
+                                    }
+                                    popupContent = popupContent + `
+                                        <tr>
+                                            <td>Seshat Pages</td>
+                                            <td>${polityLinks}</td>
+                                        </tr>
+                                    `;
                                 }
                                 popupContent = popupContent + `
                                         <tr>


### PR DESCRIPTION
- Stops these shapes from being excluded from the map
- Ensures that when a shape has multiple Seshat links, they are all displayed in the popup