### PR TITLE
Add link to websites wiki table in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ Seshat: Global History Databank brings together the most current and comprehensi
    getting-started/index
    contribute/index
    api/index
+   websites/index
 
 
 

--- a/docs/source/websites/index.rst
+++ b/docs/source/websites/index.rst
@@ -1,0 +1,6 @@
+Websites
+=============
+
+If you are a developer on the project, a table of website urls is maintained on the project's wiki: https://github.com/Seshat-Global-History-Databank/seshat/wiki/Seshat-sites
+
+If you modify any of these websites, or deploy new one's with the Seshat codebase during development, please add them to the list on the wiki, and update the date of the last edit.


### PR DESCRIPTION
I've added a table of development sites which we can keep updated here: https://github.com/Seshat-Global-History-Databank/seshat/wiki/Seshat-sites

I thought the Wiki would be a better place to locate it for easy editing, but it could live in a docs page itself. What do you think @kallewesterling ?