### PR TITLE
Cliopatria page and info on Seshat

### DIFF
--- a/seshat/apps/core/templates/core/cliopatria.html
+++ b/seshat/apps/core/templates/core/cliopatria.html
@@ -8,7 +8,8 @@
     <h2>Cliopatria</h2>
     <p>
         Cliopatria is a comprehensive open-source geospatial dataset of worldwide states, political groups, events, and rulers from 3400BCE to 2024CE.
-        It is part of the Seshat Global History Databank project and is used on the World Map and polity pages and currently the World Map is limited to 2014CE.
+        It is part of the Seshat Global History Databank project and is used on the World Map and polity pages.
+        Currently the World Map is limited to 2014CE.
         Cliopatria comprises over 1800 political entities sampled at varying timesteps and spatial scales. Many, but not all of these are linked to Seshat's polity pages, which provide detailed information on each polity.
         Released versions may be accessed on <a href="https://github.com/Seshat-Global-History-Databank/cliopatria"class="fw-bold">GitHub</a> or <a href="https://zenodo.org/records/13363121" class="fw-bold">Zenodo</a>.
     </p>

--- a/seshat/apps/core/templates/core/cliopatria.html
+++ b/seshat/apps/core/templates/core/cliopatria.html
@@ -7,10 +7,11 @@
 <div class="container pt-4">
     <h2>Cliopatria</h2>
     <p>
-        Cliopatria is a comprehensive open-source geospatial dataset of worldwide states, political groups, events, and rulers from 3400BCE to 2024CE.
+        Cliopatria is a comprehensive open-source geospatial dataset of worldwide states, political groups, events, and rulers from 3400BCE to the present day.
         It is part of the Seshat Global History Databank project and is used on the World Map and polity pages.
         Cliopatria comprises over 1800 political entities sampled at varying timesteps and spatial scales. Many, but not all of these are linked to Seshat's polity pages, which provide detailed information on each polity.
         Released versions may be accessed on <a href="https://github.com/Seshat-Global-History-Databank/cliopatria"class="fw-bold">GitHub</a> or <a href="https://zenodo.org/records/13363121" class="fw-bold">Zenodo</a>.
+        Seshat uses the latest release of Cliopatria and will update the map pages as new versions are released.
     </p>
     <p>
         While we strive to reflect the most current historical knowledge, we acknowledge that these maps reflect only one version of the territory held by past polities.

--- a/seshat/apps/core/templates/core/cliopatria.html
+++ b/seshat/apps/core/templates/core/cliopatria.html
@@ -8,8 +8,8 @@
     <h2>Cliopatria</h2>
     <p>
         Cliopatria is a comprehensive open-source geospatial dataset of worldwide states, political groups, events, and rulers from 3400BCE to 2024CE.
-        It is part of the Seshat Global History Databank project.
-        Presently it comprises over 1800 political entities sampled at varying timesteps and spatial scales.
+        It is part of the Seshat Global History Databank project and is used on the World Map and polity pages and currently the World Map is limited to 2014CE.
+        Cliopatria comprises over 1800 political entities sampled at varying timesteps and spatial scales. Many, but not all of these are linked to Seshat's polity pages, which provide detailed information on each polity.
         Released versions may be accessed on <a href="https://github.com/Seshat-Global-History-Databank/cliopatria"class="fw-bold">GitHub</a> or <a href="https://zenodo.org/records/13363121" class="fw-bold">Zenodo</a>.
     </p>
     <p>

--- a/seshat/apps/core/templates/core/cliopatria.html
+++ b/seshat/apps/core/templates/core/cliopatria.html
@@ -9,7 +9,6 @@
     <p>
         Cliopatria is a comprehensive open-source geospatial dataset of worldwide states, political groups, events, and rulers from 3400BCE to 2024CE.
         It is part of the Seshat Global History Databank project and is used on the World Map and polity pages.
-        Currently the World Map is limited to 2014CE.
         Cliopatria comprises over 1800 political entities sampled at varying timesteps and spatial scales. Many, but not all of these are linked to Seshat's polity pages, which provide detailed information on each polity.
         Released versions may be accessed on <a href="https://github.com/Seshat-Global-History-Databank/cliopatria"class="fw-bold">GitHub</a> or <a href="https://zenodo.org/records/13363121" class="fw-bold">Zenodo</a>.
     </p>

--- a/seshat/apps/core/templates/core/cliopatria.html
+++ b/seshat/apps/core/templates/core/cliopatria.html
@@ -1,0 +1,25 @@
+{% extends "core/seshat-base.html" %}
+
+<!-- NavBar -->
+{% block content-home %}
+
+
+<div class="container pt-4">
+    <h2>Cliopatria</h2>
+    <p>
+        Cliopatria is a comprehensive open-source geospatial dataset of worldwide states, political groups, events, and rulers from 3400BCE to 2024CE.
+        It is part of the Seshat Global History Databank project.
+        Presently it comprises over 1800 political entities sampled at varying timesteps and spatial scales.
+        Released versions may be accessed on <a href="https://github.com/Seshat-Global-History-Databank/cliopatria"class="fw-bold">GitHub</a> or <a href="https://zenodo.org/records/13363121" class="fw-bold">Zenodo</a>.
+    </p>
+    <p>
+        While we strive to reflect the most current historical knowledge, we acknowledge that these maps reflect only one version of the territory held by past polities.
+        Border uncertainties, as well as differing opinions on the names, territorial changes, and durations of polities, are common challenges facing historians.
+        We welcome feedback and suggestions for improvement. Following [standard Seshat protocol](https://seshatdatabank.info/methods/world-sample-30), any reported errors will be addressed after expert historian review.
+    </p>
+    <p> 
+        Please note that users and analysts of this map data are solely responsible for assessing its suitability for their
+        specific purposes.
+    </p>
+</div>
+{% endblock content-home %}

--- a/seshat/apps/core/templates/core/cliopatria.html
+++ b/seshat/apps/core/templates/core/cliopatria.html
@@ -15,7 +15,7 @@
     <p>
         While we strive to reflect the most current historical knowledge, we acknowledge that these maps reflect only one version of the territory held by past polities.
         Border uncertainties, as well as differing opinions on the names, territorial changes, and durations of polities, are common challenges facing historians.
-        We welcome feedback and suggestions for improvement. Following [standard Seshat protocol](https://seshatdatabank.info/methods/world-sample-30), any reported errors will be addressed after expert historian review.
+        We welcome feedback and suggestions for improvement. Following <a href="https://seshatdatabank.info/methods/world-sample-30">standard Seshat protocol</a>, any reported errors will be addressed after expert historian review.
     </p>
     <p> 
         Please note that users and analysts of this map data are solely responsible for assessing its suitability for their

--- a/seshat/apps/core/templates/core/old_downloads.html
+++ b/seshat/apps/core/templates/core/old_downloads.html
@@ -175,6 +175,15 @@
     <li>Hoyer, Daniel, James S Bennett, Samantha Holder, Robert Howard, Jill Levine, Peter Turchin, Jenny Reddish, Majid Benam, Francis Ludlow, and Gary M Feinman. (Forthcoming).&nbsp;&ldquo;Navigating Polycrisis: Long-Run Socio-Cultural Factors Shape Response to Changing Climate.&rdquo;&nbsp;<i>Philosophical Transactions of the Royal Society B</i>&nbsp;Special Issue: Climate change adaptation needs a science of culture, edited by Anne C Pisor, J. Stephen Lansing, and Kate Magargal..&nbsp;<a href="https://doi.org/10.1098/rstb.2022.0402">https://doi.org/10.1098/rstb.2022.0402</a>.</li>
 </ul>
 
+<h3 class="pt-2"><em>Cliopatria Dataset</em></h3>
+
+<p>Cliopatria is a comprehensive open-source geospatial dataset of worldwide states, political groups, events, and rulers
+from 3400BCE to 2024CE</p>
+
+<p>Download the Cliopatria dataset from <a href="https://zenodo.org/records/13363121"class="fw-bold">Zenodo</a></p>
+
+<p>Information on the dataset can be found in the <a href="https://github.com/Seshat-Global-History-Databank/cliopatria" class="fw-bold">GitHub repository</a></p>
+
 <p></p>
 </div>
 {% endblock content-home %}

--- a/seshat/apps/core/templates/core/polity_map.html
+++ b/seshat/apps/core/templates/core/polity_map.html
@@ -48,6 +48,7 @@
                 <fieldset>
 		            <div>
 			            <h2 class="h1 text-teal federicka-big" id="sliderDate"></h2>
+                        <p><a href="../cliopatria">Learn more about this dataset.</a></p>
                         <label for="enterYear">Enter year:</label>
                         <input type="number" id="enterYear" name="enterYear" value="{{ content.display_year }}" style="width: 75px;""><br>
                         <label for="enterYear">Increment (years):</label>

--- a/seshat/apps/core/templates/core/world_map.html
+++ b/seshat/apps/core/templates/core/world_map.html
@@ -158,6 +158,7 @@
                 </div>
 
                 <div class="slidecontainer">
+                    <p style="display: none;" id="cliopatria-link"><a href="../cliopatria" target="_blank">Learn more about this dataset.</a></p>
                     <label for="chooseVariable">Variable: </label>
                     <select name="chooseVariable" id="chooseVariable" onchange="clearSelection();" style="width: 150px; text-overflow: ellipsis;" disabled>
                         <option value="polity">Polity</option>
@@ -388,6 +389,7 @@
                         plotPolities();
                         allPolitiesLoaded = true;
                         document.getElementById('loadingIndicator').style.display = 'none';
+                        document.getElementById('cliopatria-link').style.display = 'block';
 
                         return fetch('/core/world_map_all_with_vars');
                     })
@@ -407,6 +409,7 @@
                         allVariablesLoaded = true;
                         plotPolities();
                         document.getElementById('variablesLoadingIndicator').style.display = 'none';
+                        document.getElementById('cliopatria-link').style.display = 'block';
 
                         return fetch('/core/provinces_and_countries');
                     })
@@ -429,6 +432,7 @@
                         });
 
                         document.getElementById('baseMapCurrentLoadingIndicator').style.display = 'none';
+                        document.getElementById('cliopatria-link').style.display = 'block';
                         document.getElementById('baseMapCurrent').disabled = false;
 
                     });
@@ -497,6 +501,7 @@
                 var initialDisplayYear = {{ display_year }};
                 if (selectedYear != initialDisplayYear) {
                     document.getElementById('loadingIndicator').style.display = 'block';
+                    document.getElementById('cliopatria-link').style.display = 'none';
                 }
             }
 
@@ -1019,6 +1024,7 @@
         allPolitiesLoaded = true;
         plotPolities()
         document.getElementById('loadingIndicator').style.display = 'none';
+        document.getElementById('cliopatria-link').style.display = 'block';
         allPolitiesLoaded = false;
 
         // Display slider value

--- a/seshat/apps/core/urls.py
+++ b/seshat/apps/core/urls.py
@@ -176,3 +176,6 @@ urlpatterns += [path('core/world_map/', views.map_view_initial, name='world_map'
 urlpatterns += [path('core/world_map_all/', views.map_view_all, name='world_map_all'),]
 urlpatterns += [path('core/world_map_all_with_vars/', views.map_view_all_with_vars, name='world_map_all_with_vars'),]
 urlpatterns += [path('core/provinces_and_countries', views.provinces_and_countries_view, name='provinces_and_countries'),]
+
+# Cliopatria page
+urlpatterns += [path('core/cliopatria/', views.cliopatria, name='cliopatria'),]

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -3917,9 +3917,10 @@ def get_polity_shape_content(displayed_year="all", seshat_id="all", tick_number=
         latest_year = result['max_year']
         initial_displayed_year = earliest_year
     else:
-        earliest_year, latest_year = 2014, 2014
+        earliest_year, latest_year = 2024, 2024  # These are not used in the web app, but are set to avoid errors when running migrations
         initial_displayed_year = -3400
 
+    # Overrides can be set to restrict the years shown on the map
     if override_earliest_year is not None:
         earliest_year = override_earliest_year
     if override_latest_year is not None:
@@ -4353,7 +4354,7 @@ def common_map_view_content(content):
     content['world_map_initial_polity'] = world_map_initial_polity
 
     # Set the last year in history we ever want to display, which will be used to determine when we should say "present"
-    content['last_history_year'] = last_history_year
+    content['last_history_year'] = content['latest_year']  # Set this to the latest year in the data or a value of choice
 
     return content
 
@@ -4375,13 +4376,12 @@ def dummy_map_view_content(content):
     content['world_map_initial_polity'] = world_map_initial_polity
 
     # Set the last year in history we ever want to display, which will be used to determine when we should say "present"
-    content['last_history_year'] = last_history_year
+    content['last_history_year'] = content['latest_year']  # Set this to the latest year in the data or a value of choice
     return content
 
 # World map default settings
 world_map_initial_displayed_year = 117
 world_map_initial_polity = 'it_roman_principate'
-last_history_year = 2014
 
 def map_view_initial(request):
     global world_map_initial_displayed_year, world_map_initial_polity
@@ -4407,7 +4407,7 @@ def map_view_initial(request):
             world_map_initial_displayed_year, world_map_initial_polity = random_polity_shape()
         return redirect('{}?year={}'.format(request.path, world_map_initial_displayed_year))
 
-    content = get_polity_shape_content(displayed_year=world_map_initial_displayed_year, override_latest_year=last_history_year)
+    content = get_polity_shape_content(displayed_year=world_map_initial_displayed_year)
 
     content = dummy_map_view_content(content)
 
@@ -4428,7 +4428,7 @@ def map_view_all(request):
         JsonResponse: The HTTP response with serialized JSON.
     """
 
-    content = get_polity_shape_content(override_latest_year=last_history_year)
+    content = get_polity_shape_content()
 
     content = dummy_map_view_content(content)
 
@@ -4446,7 +4446,7 @@ def map_view_all_with_vars(request):
         JsonResponse: The HTTP response with serialized JSON.
     """
 
-    content = get_polity_shape_content(override_latest_year=last_history_year)
+    content = get_polity_shape_content()
 
     content = common_map_view_content(content)
 

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -5218,3 +5218,5 @@ def xxyyzz(request, com_id):
 
     return redirect(reverse('seshatprivatecomment-update', kwargs={'pk': com_id}))
 
+def cliopatria(request):
+    return render(request, 'core/cliopatria.html')


### PR DESCRIPTION
I have added a Cliopatria page to the Seshat website, which has the same info as on the GitHub repo, but with a bit of added context for Seshat. Below see how it looks, and the links to that page on the polity pages and world map, and finally a short addition to the Downloads page at the bottom.

<img width="1511" alt="Screenshot 2024-08-23 at 14 50 28" src="https://github.com/user-attachments/assets/9c0b4633-e4cc-4b85-b76a-6083b7d128c9">

# Linked to on polity pages and word map

<img width="1510" alt="Screenshot 2024-08-23 at 14 50 38" src="https://github.com/user-attachments/assets/9b684bc4-e660-4c31-83d9-a5eb5cbeaa47">
<img width="1506" alt="Screenshot 2024-08-23 at 14 50 57" src="https://github.com/user-attachments/assets/957172d7-2877-49a7-bc64-6077860a73c4">

# Download page

<img width="1505" alt="Screenshot 2024-08-23 at 14 50 12" src="https://github.com/user-attachments/assets/7bfe91f0-52d1-41e7-961d-4683aa742b9a">


