### PR TITLE
Add CESIUM_ION_ACCESS to .env

### DIFF
--- a/docs/source/admin/setup/cloud/CSH_manual.rst
+++ b/docs/source/admin/setup/cloud/CSH_manual.rst
@@ -288,6 +288,17 @@ To create the .env file in the same directory as the manage.py file: (/home/ubun
 
     vim .env
 
+.. admonition:: Get a Cesium access token
+    :class: dropdown
+
+    You will also need to generate an access token for Cesium in order for the globe to render on Seshat pages that include maps.
+
+    Visit the `Cesium website <https://ion.cesium.com/>`_ and create an account.
+
+    Once you have an account, navigate to the "Access Tokens" tab and create a new token.
+
+    Add this token to the ``.env`` file as shown below.
+
 The content of the .env file should look something like this:
 
 .. code-block:: none
@@ -311,6 +322,7 @@ The content of the .env file should look something like this:
     ZOTERO_API_KEY = '<api_key>'
     # For future use
     EMAIL_APP_PASS = '<email_password>'
+    CESIUM_ION_ACCESS='<cesium_access_token>''
 
 We now need to ask Django to bring all the static files of the project (CSS files, images, etc.) together. Inside the virtual environment and in the same path as manage.py:
 

--- a/docs/source/admin/setup/local/macos.rst
+++ b/docs/source/admin/setup/local/macos.rst
@@ -201,6 +201,17 @@ Create a configuration file with your database info for Django. The presence of 
 
 Within the repo, create a file called ``seshat/settings/.env`` with the database connection variables.
 
+.. admonition:: Get a Cesium access token
+    :class: dropdown
+
+    You will also need to generate an access token for Cesium in order for the globe to render on Seshat pages that include maps.
+
+    Visit the `Cesium website <https://ion.cesium.com/>`_ and create an account.
+
+    Once you have an account, navigate to the "Access Tokens" tab and create a new token.
+
+    Add this token to the ``.env`` file as shown below.
+
 The file should look like this:
 
 .. code-block::
@@ -210,6 +221,7 @@ The file should look like this:
     DB_HOST=localhost
     DB_PORT=5432
     DB_PASSWORD=<db_password>
+    CESIUM_ION_ACCESS=<cesium_access_token>
 
 
 Step 9: Migrate the database

--- a/docs/source/admin/setup/local/ubuntu.rst
+++ b/docs/source/admin/setup/local/ubuntu.rst
@@ -230,6 +230,17 @@ Create a configuration file with your database info for Django. The presence of 
 
 Within the repo, create a file called ``seshat/settings/.env`` with the database connection variables.
 
+.. admonition:: Get a Cesium access token
+    :class: dropdown
+
+    You will also need to generate an access token for Cesium in order for the globe to render on Seshat pages that include maps.
+
+    Visit the `Cesium website <https://ion.cesium.com/>`_ and create an account.
+
+    Once you have an account, navigate to the "Access Tokens" tab and create a new token.
+
+    Add this token to the ``.env`` file as shown below.
+
 The file should look like this:
 
 .. code-block::
@@ -239,6 +250,7 @@ The file should look like this:
     DB_HOST=localhost
     DB_PORT=5432
     DB_PASSWORD=<db_password>
+    CESIUM_ION_ACCESS=<cesium_access_token>
 
 
 Step 9: Migrate the database


### PR DESCRIPTION
Update the docs pages to explain how to generate the required access token for Cesium which is used by maps pages, and add it to the django settings config