### PR TITLE
Speed up variables loading on world map page

### DIFF
--- a/seshat/apps/core/templates/core/world_map.html
+++ b/seshat/apps/core/templates/core/world_map.html
@@ -436,6 +436,9 @@
     <script src="{% static 'core/js/map_functions.js' %}"></script>
     <script>
 
+        // Start a new timer to measure the time it takes to load the page
+        console.time('Initial load time');
+
         function adjustScroll() {
             const slider = document.getElementById('dateSlide');
             const sliderDiv = document.getElementById('sliderdiv');
@@ -480,6 +483,9 @@
 
         // Show me the size of the shapesData in MB (for debugging)
         console.log('Initial shapesData size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
+
+        // Show me the time that has passed since the page started loading
+        console.timeEnd('Initial load time');
 
         // Iterate through shapesData and ensure that fields that are lists are interpreted properly
         // TODO: find a way to avoid having to do this
@@ -552,6 +558,8 @@
         var tick_years = {{ tick_years }};
         setSliderTicks(tick_years);
 
+        console.time('All load time');
+
         // Load all polity shapes and modern province/country shapes in background
         window.addEventListener('load', function () {
             function fetchData(url, displayYear) {
@@ -565,6 +573,7 @@
                                 shapesData.push(shape);
                             });
                         console.log('shapesDataAll size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
+                        console.timeEnd('All load time');
 
                         seshat_id_page_id = data.seshat_id_page_id;
                         allCapitalsInfo = data.all_capitals_info;
@@ -576,6 +585,8 @@
                         allPolitiesLoaded = true;
                         document.getElementById('loadingIndicator').style.display = 'none';
                         document.getElementById('cliopatria-link').style.display = 'block';
+
+                        console.time('Vars load time');
 
                         return fetch('/core/world_map_all_with_vars');
                     })
@@ -589,6 +600,7 @@
                         });
                         shapesData = shapesDataWithVars;
                         console.log('shapesDataWithVars size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
+                        console.timeEnd('Vars load time');
                         populateVariableDropdown(data.variables);
                         document.getElementById('chooseVariable').disabled = false;
                         categorical_variables = data.categorical_variables;

--- a/seshat/apps/core/templates/core/world_map.html
+++ b/seshat/apps/core/templates/core/world_map.html
@@ -478,6 +478,9 @@
             {% endfor %}
         ];
 
+        // Show me the size of the shapesData in MB (for debugging)
+        console.log('Initial shapesData size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
+
         // Iterate through shapesData and ensure that fields that are lists are interpreted properly
         // TODO: find a way to avoid having to do this
         shapesData.forEach(function (shape) {
@@ -561,6 +564,7 @@
                                 shape.weight = polityBorderWeight;
                                 shapesData.push(shape);
                             });
+                        console.log('shapesDataAll size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
 
                         seshat_id_page_id = data.seshat_id_page_id;
                         allCapitalsInfo = data.all_capitals_info;
@@ -584,6 +588,7 @@
                             return shape;
                         });
                         shapesData = shapesDataWithVars;
+                        console.log('shapesDataWithVars size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
                         populateVariableDropdown(data.variables);
                         document.getElementById('chooseVariable').disabled = false;
                         categorical_variables = data.categorical_variables;

--- a/seshat/apps/core/templates/core/world_map.html
+++ b/seshat/apps/core/templates/core/world_map.html
@@ -598,6 +598,13 @@
                             shape.weight = existingShape ? existingShape.weight : polityBorderWeight;
                             return shape;
                         });
+
+                        // Add the geom_json field from each shape in shapesData to the corresponding shape in shapesDataWithVars
+                        shapesDataWithVars.forEach(shape => {
+                            let existingShape = shapesData.find(existing => existing.id === shape.id);
+                            shape.geom_json = existingShape ? existingShape.geom_json : null;
+                        });
+
                         shapesData = shapesDataWithVars;
                         console.log('shapesDataWithVars size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
                         console.timeEnd('Vars load time');

--- a/seshat/apps/core/templates/core/world_map.html
+++ b/seshat/apps/core/templates/core/world_map.html
@@ -436,9 +436,6 @@
     <script src="{% static 'core/js/map_functions.js' %}"></script>
     <script>
 
-        // Start a new timer to measure the time it takes to load the page
-        console.time('Initial load time');
-
         function adjustScroll() {
             const slider = document.getElementById('dateSlide');
             const sliderDiv = document.getElementById('sliderdiv');
@@ -480,12 +477,6 @@
                 },
             {% endfor %}
         ];
-
-        // Show me the size of the shapesData in MB (for debugging)
-        console.log('Initial shapesData size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
-
-        // Show me the time that has passed since the page started loading
-        console.timeEnd('Initial load time');
 
         // Iterate through shapesData and ensure that fields that are lists are interpreted properly
         // TODO: find a way to avoid having to do this
@@ -558,8 +549,6 @@
         var tick_years = {{ tick_years }};
         setSliderTicks(tick_years);
 
-        console.time('All load time');
-
         // Load all polity shapes and modern province/country shapes in background
         window.addEventListener('load', function () {
             function fetchData(url, displayYear) {
@@ -572,8 +561,6 @@
                                 shape.weight = polityBorderWeight;
                                 shapesData.push(shape);
                             });
-                        console.log('shapesDataAll size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
-                        console.timeEnd('All load time');
 
                         seshat_id_page_id = data.seshat_id_page_id;
                         allCapitalsInfo = data.all_capitals_info;
@@ -585,8 +572,6 @@
                         allPolitiesLoaded = true;
                         document.getElementById('loadingIndicator').style.display = 'none';
                         document.getElementById('cliopatria-link').style.display = 'block';
-
-                        console.time('Vars load time');
 
                         return fetch('/core/world_map_all_with_vars');
                     })
@@ -606,8 +591,6 @@
                         });
 
                         shapesData = shapesDataWithVars;
-                        console.log('shapesDataWithVars size: ' + (JSON.stringify(shapesData).length / 1024 / 1024).toFixed(2) + ' MB');
-                        console.timeEnd('Vars load time');
                         populateVariableDropdown(data.variables);
                         document.getElementById('chooseVariable').disabled = false;
                         categorical_variables = data.categorical_variables;

--- a/seshat/apps/core/tests/tests.py
+++ b/seshat/apps/core/tests/tests.py
@@ -256,6 +256,52 @@ class ShapesTest(TestCase):
 
         self.assertEqual(result, expected_result)
 
+    def test_get_polity_shape_content_no_geometries(self):
+        """Test the get_polity_shape_content function with geometries=False."""
+        expected_result = {
+            'shapes': [
+                {
+                    'seshat_id': 'IqAbbs1',
+                    'name': 'Testpolityname',
+                    'start_year': 2000,
+                    'end_year': 2020,
+                    'polity_start_year': 2000,
+                    'polity_end_year': 2020,
+                    'colour': "#FFFFFF",
+                    'area': 100.0,
+                    'id': 1,
+                    'components': 'Test components',
+                    'member_of': 'Test member_of',
+                    'wikipedia_name': 'Test Wikipedia'
+                },
+                {
+                    'seshat_id': 'Cn5Dyna',
+                    'name': 'Testpolityname2',
+                    'start_year': 0,
+                    'end_year': 1000,
+                    'polity_start_year': 0,
+                    'polity_end_year': 1000,
+                    'colour': "#FFFFFF",
+                    'area': 100.0,
+                    'id': 2,
+                    'components': 'Test components',
+                    'member_of': 'Test member_of',
+                    'wikipedia_name': 'Test Wikipedia 2'
+                }
+            ],
+            'earliest_year': 0,
+            'display_year': 0,
+            'tick_years': json.dumps([0, 1010, 2020]),
+            'latest_year': 2020,
+            'seshat_id_page_id': {
+                'IqAbbs1': {'id': 1, 'long_name': 'TestPolity'},
+                'Cn5Dyna': {'id': 2, 'long_name': 'TestPolity2'}
+            }
+        }
+        result = get_polity_shape_content(tick_number=3, geometries=False)
+
+        self.assertEqual(result, expected_result)
+
     def test_get_polity_shape_content_single_year(self):
         """
             Test the get_polity_shape_content function for a single year.

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -3894,16 +3894,14 @@ def get_polity_shape_content(displayed_year="all", seshat_id="all", tick_number=
     else:
         rows = Cliopatria.objects.all()
 
-    # Convert 'geom' to GeoJSON in the database query
-    rows = rows.annotate(geom_json=AsGeoJSON('geom'))
-    # Filter the rows to return
-    rows = rows.values('id', 'seshat_id', 'name', 'start_year', 'end_year', 'polity_start_year', 'polity_end_year', 'colour', 'area', 'geom_json', 'components', 'member_of', 'wikipedia_name')
+    if geometries:
+        # Convert 'geom' to GeoJSON in the database query
+        rows = rows.annotate(geom_json=AsGeoJSON('geom'))
+        # Filter the rows to return
+        rows = rows.values('id', 'seshat_id', 'name', 'start_year', 'end_year', 'polity_start_year', 'polity_end_year', 'colour', 'area', 'geom_json', 'components', 'member_of', 'wikipedia_name') 
+    else:
+        rows = rows.values('id', 'seshat_id', 'name', 'start_year', 'end_year', 'polity_start_year', 'polity_end_year', 'colour', 'area', 'components', 'member_of', 'wikipedia_name')
     shapes = list(rows)
-
-    if not geometries:
-        # Remove the 'geom' field from shapes
-        for shape in shapes:
-            del shape['geom_json']
 
     seshat_ids = [shape['seshat_id'] for shape in shapes if shape['seshat_id']]
 

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -4332,58 +4332,6 @@ def random_polity_shape(from_selection=True):
                     break
     return shape.start_year, shape.seshat_id
 
-def common_map_view_content(content):
-    """
-    Set of functions that update content and run in each map view function.
-
-    Args:
-        content (dict): The content for the polity shapes.
-
-    Returns:
-        dict: The updated content for the polity shapes.
-    """
-
-    # Add in the present/absent variables to view for the shapes
-    content['shapes'], content['variables'] = assign_variables_to_shapes(content['shapes'], app_map)
-
-    # Add in the categorical variables to view for the shapes
-    content['shapes'], content['variables'] = assign_categorical_variables_to_shapes(content['shapes'], content['variables'])
-
-    # Load the capital cities for polities that have them
-    content['all_capitals_info'] = get_all_polity_capitals()
-    
-    # Add categorical variable choices to content for dropdown selection
-    content['categorical_variables'] = categorical_variables
-
-    # Set the initial polity to highlight
-    content['world_map_initial_polity'] = world_map_initial_polity
-
-    # Set the last year in history we ever want to display, which will be used to determine when we should say "present"
-    content['last_history_year'] = content['latest_year']  # Set this to the latest year in the data or a value of choice
-
-    return content
-
-def dummy_map_view_content(content):
-    """
-    Dummy version of common_map_view_content that adds blank dicts.
-
-    Args:
-        content (dict): The content for the polity shapes.
-
-    Returns:
-        dict: The updated content for the polity shapes.
-    """
-    content['all_capitals_info'] = {}
-    content['categorical_variables'] = {}
-    content['variables'] = {}
-
-    # Set the initial polity to highlight
-    content['world_map_initial_polity'] = world_map_initial_polity
-
-    # Set the last year in history we ever want to display, which will be used to determine when we should say "present"
-    content['last_history_year'] = content['latest_year']  # Set this to the latest year in the data or a value of choice
-    return content
-
 # World map default settings
 world_map_initial_displayed_year = 117
 world_map_initial_polity = 'it_roman_principate'
@@ -4416,7 +4364,16 @@ def map_view_initial(request):
 
     content = get_polity_shape_content(displayed_year=world_map_initial_displayed_year)
 
-    content = dummy_map_view_content(content)
+    # Set default values for these which are set properly in the subsequent map views
+    content['categorical_variables'] = {}
+    content['variables'] = {}
+    content['all_capitals_info'] = {}
+
+    # Set the initial polity to highlight
+    content['world_map_initial_polity'] = world_map_initial_polity
+
+    # Set the last year in history we ever want to display, which will be used to determine when we should say "present"
+    content['last_history_year'] = content['latest_year']  # Set this to the latest year in the data or a value of choice
 
     return render(request,
                   'core/world_map.html',
@@ -4437,7 +4394,19 @@ def map_view_all(request):
 
     content = get_polity_shape_content()
 
-    content = dummy_map_view_content(content)
+    # Set default values for these which are set properly in map_view_all_with_vars
+    content['variables'] = {}
+    content['categorical_variables'] = {}
+
+    # Load the capital cities for polities that have them
+    content['all_capitals_info'] = {}
+    # content['all_capitals_info'] = get_all_polity_capitals()  # This is currently disabled as it is not used in the frontend
+
+    # Set the initial polity to highlight
+    content['world_map_initial_polity'] = world_map_initial_polity
+
+    # Set the last year in history we ever want to display, which will be used to determine when we should say "present"
+    content['last_history_year'] = content['latest_year']  # Set this to the latest year in the data or a value of choice
 
     return JsonResponse(content)
 
@@ -4455,7 +4424,24 @@ def map_view_all_with_vars(request):
 
     content = get_polity_shape_content(geometries=False)
 
-    content = common_map_view_content(content)
+    # Add in the present/absent variables to view for the shapes
+    content['shapes'], content['variables'] = assign_variables_to_shapes(content['shapes'], app_map)
+
+    # Add in the categorical variables to view for the shapes
+    content['shapes'], content['variables'] = assign_categorical_variables_to_shapes(content['shapes'], content['variables'])
+
+    # Load the capital cities for polities that have them
+    content['all_capitals_info'] = {}
+    # content['all_capitals_info'] = get_all_polity_capitals()  # This is currently disabled as it is not used in the frontend
+    
+    # Add categorical variable choices to content for dropdown selection
+    content['categorical_variables'] = categorical_variables
+
+    # Set the initial polity to highlight
+    content['world_map_initial_polity'] = world_map_initial_polity
+
+    # Set the last year in history we ever want to display, which will be used to determine when we should say "present"
+    content['last_history_year'] = content['latest_year']  # Set this to the latest year in the data or a value of choice
 
     return JsonResponse(content)
 

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -3900,6 +3900,11 @@ def get_polity_shape_content(displayed_year="all", seshat_id="all", tick_number=
     rows = rows.values('id', 'seshat_id', 'name', 'start_year', 'end_year', 'polity_start_year', 'polity_end_year', 'colour', 'area', 'geom_json', 'components', 'member_of', 'wikipedia_name')
     shapes = list(rows)
 
+    if not geometries:
+        # Remove the 'geom' field from shapes
+        for shape in shapes:
+            del shape['geom_json']
+
     seshat_ids = [shape['seshat_id'] for shape in shapes if shape['seshat_id']]
 
     polities = Polity.objects.filter(new_name__in=seshat_ids).values('new_name', 'id', 'long_name')

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -3867,7 +3867,7 @@ def get_provinces(selected_base_map_gadm='province'):
 
     return provinces
 
-def get_polity_shape_content(displayed_year="all", seshat_id="all", tick_number=80, override_earliest_year=None, override_latest_year=None):
+def get_polity_shape_content(displayed_year="all", seshat_id="all", tick_number=80, override_earliest_year=None, override_latest_year=None, geometries=True):
     """
     This function returns the polity shapes and other content for the map.
     Only one of displayed_year or seshat_id should be set; not both.
@@ -4465,7 +4465,7 @@ def map_view_all_with_vars(request):
     # Start a timer to measure the time taken to load the page
     start_time = time.time()
 
-    content = get_polity_shape_content()
+    content = get_polity_shape_content(geometries=False)
 
     content = common_map_view_content(content)
 

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -4429,6 +4429,9 @@ def map_view_initial(request):
                   content
                   )
 
+import gzip
+from io import BytesIO
+
 def map_view_all(request):
     """
     This view is used to display a map with polities plotted on it. The view
@@ -4445,13 +4448,22 @@ def map_view_all(request):
     start_time = time.time()
 
     content = get_polity_shape_content()
-
     content = dummy_map_view_content(content)
+
+    # Compress the content using gzip
+    buffer = BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode='wb') as f:
+        f.write(json.dumps(content).encode('utf-8'))
+
+    compressed_content = buffer.getvalue()
 
     # Print the time taken to load the page
     print(f"Time taken to load the all view: {time.time() - start_time} seconds")
 
-    return JsonResponse(content)
+    response = HttpResponse(compressed_content, content_type='application/json')
+    response['Content-Encoding'] = 'gzip'
+
+    return response
 
 def map_view_all_with_vars(request):
     """
@@ -4462,20 +4474,29 @@ def map_view_all_with_vars(request):
         request: The request object.
 
     Returns:
-        JsonResponse: The HTTP response with serialized JSON.
+        HttpResponse: The HTTP response with compressed JSON.
     """
 
     # Start a timer to measure the time taken to load the page
     start_time = time.time()
 
     content = get_polity_shape_content(geometries=False)
-
     content = common_map_view_content(content)
+
+    # Compress the content using gzip
+    buffer = BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode='wb') as f:
+        f.write(json.dumps(content).encode('utf-8'))
+
+    compressed_content = buffer.getvalue()
 
     # Print the time taken to load the page
     print(f"Time taken to load the vars view: {time.time() - start_time} seconds")
 
-    return JsonResponse(content)
+    response = HttpResponse(compressed_content, content_type='application/json')
+    response['Content-Encoding'] = 'gzip'
+
+    return response
 
 def provinces_and_countries_view(request):
     """

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -4385,6 +4385,8 @@ def dummy_map_view_content(content):
 world_map_initial_displayed_year = 117
 world_map_initial_polity = 'it_roman_principate'
 
+import time
+
 def map_view_initial(request):
     global world_map_initial_displayed_year, world_map_initial_polity
     """
@@ -4398,6 +4400,9 @@ def map_view_initial(request):
     Returns:
         HttpResponse: The HTTP response.
     """
+    
+    # Start a timer to measure the time taken to load the page
+    start_time = time.time()
 
     # Check if 'year' parameter is different from the world_map_initial_displayed_year or not present then redirect
     if 'year' in request.GET:
@@ -4412,6 +4417,9 @@ def map_view_initial(request):
     content = get_polity_shape_content(displayed_year=world_map_initial_displayed_year)
 
     content = dummy_map_view_content(content)
+
+    # Print the time taken to load the page
+    print(f"Time taken to load the initial view: {time.time() - start_time} seconds")
 
     return render(request,
                   'core/world_map.html',
@@ -4430,9 +4438,15 @@ def map_view_all(request):
         JsonResponse: The HTTP response with serialized JSON.
     """
 
+    # Start a timer to measure the time taken to load the page
+    start_time = time.time()
+
     content = get_polity_shape_content()
 
     content = dummy_map_view_content(content)
+
+    # Print the time taken to load the page
+    print(f"Time taken to load the all view: {time.time() - start_time} seconds")
 
     return JsonResponse(content)
 
@@ -4448,9 +4462,15 @@ def map_view_all_with_vars(request):
         JsonResponse: The HTTP response with serialized JSON.
     """
 
+    # Start a timer to measure the time taken to load the page
+    start_time = time.time()
+
     content = get_polity_shape_content()
 
     content = common_map_view_content(content)
+
+    # Print the time taken to load the page
+    print(f"Time taken to load the vars view: {time.time() - start_time} seconds")
 
     return JsonResponse(content)
 

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -4429,9 +4429,6 @@ def map_view_initial(request):
                   content
                   )
 
-import gzip
-from io import BytesIO
-
 def map_view_all(request):
     """
     This view is used to display a map with polities plotted on it. The view
@@ -4448,22 +4445,13 @@ def map_view_all(request):
     start_time = time.time()
 
     content = get_polity_shape_content()
+
     content = dummy_map_view_content(content)
-
-    # Compress the content using gzip
-    buffer = BytesIO()
-    with gzip.GzipFile(fileobj=buffer, mode='wb') as f:
-        f.write(json.dumps(content).encode('utf-8'))
-
-    compressed_content = buffer.getvalue()
 
     # Print the time taken to load the page
     print(f"Time taken to load the all view: {time.time() - start_time} seconds")
 
-    response = HttpResponse(compressed_content, content_type='application/json')
-    response['Content-Encoding'] = 'gzip'
-
-    return response
+    return JsonResponse(content)
 
 def map_view_all_with_vars(request):
     """
@@ -4474,29 +4462,20 @@ def map_view_all_with_vars(request):
         request: The request object.
 
     Returns:
-        HttpResponse: The HTTP response with compressed JSON.
+        JsonResponse: The HTTP response with serialized JSON.
     """
 
     # Start a timer to measure the time taken to load the page
     start_time = time.time()
 
     content = get_polity_shape_content(geometries=False)
+
     content = common_map_view_content(content)
-
-    # Compress the content using gzip
-    buffer = BytesIO()
-    with gzip.GzipFile(fileobj=buffer, mode='wb') as f:
-        f.write(json.dumps(content).encode('utf-8'))
-
-    compressed_content = buffer.getvalue()
 
     # Print the time taken to load the page
     print(f"Time taken to load the vars view: {time.time() - start_time} seconds")
 
-    response = HttpResponse(compressed_content, content_type='application/json')
-    response['Content-Encoding'] = 'gzip'
-
-    return response
+    return JsonResponse(content)
 
 def provinces_and_countries_view(request):
     """

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -4403,9 +4403,6 @@ def map_view_initial(request):
     Returns:
         HttpResponse: The HTTP response.
     """
-    
-    # Start a timer to measure the time taken to load the page
-    start_time = time.time()
 
     # Check if 'year' parameter is different from the world_map_initial_displayed_year or not present then redirect
     if 'year' in request.GET:
@@ -4420,9 +4417,6 @@ def map_view_initial(request):
     content = get_polity_shape_content(displayed_year=world_map_initial_displayed_year)
 
     content = dummy_map_view_content(content)
-
-    # Print the time taken to load the page
-    print(f"Time taken to load the initial view: {time.time() - start_time} seconds")
 
     return render(request,
                   'core/world_map.html',
@@ -4441,15 +4435,9 @@ def map_view_all(request):
         JsonResponse: The HTTP response with serialized JSON.
     """
 
-    # Start a timer to measure the time taken to load the page
-    start_time = time.time()
-
     content = get_polity_shape_content()
 
     content = dummy_map_view_content(content)
-
-    # Print the time taken to load the page
-    print(f"Time taken to load the all view: {time.time() - start_time} seconds")
 
     return JsonResponse(content)
 
@@ -4465,15 +4453,9 @@ def map_view_all_with_vars(request):
         JsonResponse: The HTTP response with serialized JSON.
     """
 
-    # Start a timer to measure the time taken to load the page
-    start_time = time.time()
-
     content = get_polity_shape_content(geometries=False)
 
     content = common_map_view_content(content)
-
-    # Print the time taken to load the page
-    print(f"Time taken to load the vars view: {time.time() - start_time} seconds")
 
     return JsonResponse(content)
 

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -180,7 +180,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
-    "django.middleware.gzip.GZipMiddleware",
 
 ]
 """MIDDLEWARE defines the list of middleware classes that Django will use."""

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -180,6 +180,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.middleware.gzip.GZipMiddleware",
 
 ]
 """MIDDLEWARE defines the list of middleware classes that Django will use."""


### PR DESCRIPTION
Closes #84 

Refactors the `map_view_all_with_vars` to avoid loading all the geometries twice

TODO:
- [x] Try minimal shape id to seshat id mapping for variables func - did not increase speed further (see `load-vars-separately-2`)
- [x] Refactor common map view content?
- [x] Docstrings
- [x] There appears to be an un-noticed bug in that `allCapitalsInfo` is only being generated for the "variables" view but being set for the "all" view (where it is a blank dict) - for now we could set this to a blank dict in both but leave a comment with the capitals function to come back to later