### PR TITLE
Added External Expert to the list of users on Index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,8 @@ The documentation is divided into sections based on the role of the reader, whic
 1. Seshat Databank Admin: A member of the Seshat team responsible for the maintenance and development of the Seshat codebase, database and website.
 2. Researcher: Any researcher contributing to, or consuming, the Seshat data as part of an ongoing Seshat affiliated project.
 3. Seshat Expert: A collaborator with the necessary expertise and permission to approve or reject changes to the Seshat data.
-4. Public User: An academic or other interested party who has created an account on the Seshat website to suggest data edits.
+4. External Seshat Expert: User: An external collaborator who has the necessary expertise to review and make private comments on Seshat records.
+5. Public User: An academic or other interested party who has created an account on the Seshat website to suggest data edits.
 
 Project Documentation
 ---------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ The documentation is divided into sections based on the role of the reader, whic
 1. Seshat Databank Admin: A member of the Seshat team responsible for the maintenance and development of the Seshat codebase, database and website.
 2. Researcher: Any researcher contributing to, or consuming, the Seshat data as part of an ongoing Seshat affiliated project.
 3. Seshat Expert: A collaborator with the necessary expertise and permission to approve or reject changes to the Seshat data.
-4. External Seshat Expert: User: An external collaborator who has the necessary expertise to review and make private comments on Seshat records.
+4. External Seshat Expert: An external collaborator who has the necessary expertise to review and make private comments on Seshat records.
 5. Public User: An academic or other interested party who has created an account on the Seshat website to suggest data edits.
 
 Project Documentation


### PR DESCRIPTION
External Experts are also a separate group of users and deserve to get their separate page on the docs.