### PR TITLE
Widening the docs page using custom.css

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: 100% !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,6 +109,9 @@ html_static_path = ["_static"]
 html_theme_options = {
     "use_download_button": True,
 }
+html_css_files = [
+    'custom.css',
+]
 
 # -- copybutton settings ----
 


### PR DESCRIPTION
I am trying to see if we can change the styling of the docs page. I have changed a small setting in conf.py and added /_static/custom.css