### PR TITLE
Docs previews on PR with Readthedocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,6 @@ on:
       - dev
     paths:
       - 'docs/**'
-  pull_request:
-    branches:
-      - dev
-    paths:
-      - 'docs/**'
   workflow_dispatch:
 permissions:
     contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,14 @@ on:
     branches: [dev]
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [dev]
     paths-ignore:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - '.github/ISSUE_TEMPLATE/**'
 
 jobs:
   test_core:

--- a/docs/source/team.rst
+++ b/docs/source/team.rst
@@ -24,7 +24,7 @@ Follow the example of the existing bios, adding the following sections:
 Contact
 -------
 
-If you need to contact someone from the team, email them or use one of the communication channels listed below.
+If you need to contact a member of the team, email them or use one of the communication channels listed below.
 Some team members have also added a bio to this page explaining what they can help with and their administrative privileges for the Seshat website.
 
 .. list-table:: Team Members


### PR DESCRIPTION
Closes #157 
- [x] Remove the original docs action
- ~~Ensure the readthedocs build is only triggered by edits to docs pages~~ I'm not bothered by this - if you make changes to code only and the docs are still building but other tests have passed you can still hit merge as we haven't set up rules