### PR TITLE
Single list of ABSENT_PRESENT_CHOICES

### DIFF
--- a/seshat/apps/core/tests/tests.py
+++ b/seshat/apps/core/tests/tests.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from ..models import Cliopatria, GADMShapefile, GADMCountries, GADMProvinces, Polity, Capital
 from ...general.models import Polity_capital, Polity_peak_years, Polity_language, Polity_religious_tradition
 from ...sc.models import Judge
+from ...wf.models import Copper
 from ...rt.models import Gov_res_pub_pros
 from ..views import get_provinces, get_polity_shape_content, get_all_polity_capitals, assign_variables_to_shapes, assign_categorical_variables_to_shapes
 from ..templatetags.core_tags import get_polity_capitals, polity_map
@@ -133,6 +134,13 @@ class ShapesTest(TestCase):
         Judge.objects.create(
             name='judge',
             judge='present',
+            year_from=2003,
+            year_to=2004,
+            polity_id=2
+        )
+        Copper.objects.create(
+            name='copper',
+            copper='present',
             year_from=2003,
             year_to=2004,
             polity_id=2
@@ -530,18 +538,25 @@ class ShapesTest(TestCase):
             'formatted': 'Judge',
             'full_name': 'Law: Judge'
         }
+        expected_result_variables_copper = {
+            'formatted': 'Copper',
+            'full_name': 'Military use of Metals: Copper'
+        }
         expected_result_variables_gov_res_pub_pros = {
             'formatted': 'Government Restrictions on Public Proselytizings',
             'full_name': 'Government Restrictions: Government Restrictions on Public Proselytizings'
         }
         self.assertEqual(result_variables['Social Complexity Variables']['judge'], expected_result_variables_judge)
+        self.assertEqual(result_variables['Warfare Variables (Military Technologies)']['copper'], expected_result_variables_copper)
 
         # TODO: This test was broken by PR #171 - see bug issue #187
         # self.assertEqual(result_variables['Religion Tolerance']['gov_res_pub_pros'], expected_result_variables_gov_res_pub_pros)
 
         # Test that the shapes have been updated with the variables
         self.assertEqual(result_shapes[0]['Judge'], 'present')
-        # self.assertEqual(result_shapes[0]['Judge_dict'], {'present': [2003, 2004]})
+        # self.assertEqual(result_shapes[0]['Judge_dict'], {'present': [2003, 2004]})  # TODO: unsure why this was commented out
+        self.assertEqual(result_shapes[0]['Copper'], 'present')
+        # self.assertEqual(result_shapes[0]['Copper_dict'], {'present': [2003, 2004]})
 
         # TODO: These tests wer broken by PR #171 - see bug issue #187
         # self.assertEqual(result_shapes[0]['Government Restrictions on Public Proselytizings'], 'absent')

--- a/seshat/apps/core/tests/tests.py
+++ b/seshat/apps/core/tests/tests.py
@@ -554,7 +554,7 @@ class ShapesTest(TestCase):
 
         # Test that the shapes have been updated with the variables
         self.assertEqual(result_shapes[0]['Judge'], 'present')
-        # self.assertEqual(result_shapes[0]['Judge_dict'], {'present': [2003, 2004]})  # TODO: unsure why this was commented out
+        self.assertEqual(result_shapes[0]['Judge_dict'], {'present': [2003, 2004]})
         self.assertEqual(result_shapes[0]['Copper'], 'present')
         # self.assertEqual(result_shapes[0]['Copper_dict'], {'present': [2003, 2004]})
 

--- a/seshat/apps/core/tests/tests.py
+++ b/seshat/apps/core/tests/tests.py
@@ -548,19 +548,15 @@ class ShapesTest(TestCase):
         }
         self.assertEqual(result_variables['Social Complexity Variables']['judge'], expected_result_variables_judge)
         self.assertEqual(result_variables['Warfare Variables (Military Technologies)']['copper'], expected_result_variables_copper)
-
-        # TODO: This test was broken by PR #171 - see bug issue #187
-        # self.assertEqual(result_variables['Religion Tolerance']['gov_res_pub_pros'], expected_result_variables_gov_res_pub_pros)
+        self.assertEqual(result_variables['Religion Tolerance']['gov_res_pub_pros'], expected_result_variables_gov_res_pub_pros)
 
         # Test that the shapes have been updated with the variables
         self.assertEqual(result_shapes[0]['Judge'], 'present')
         self.assertEqual(result_shapes[0]['Judge_dict'], {'present': [2003, 2004]})
         self.assertEqual(result_shapes[0]['Copper'], 'present')
         self.assertEqual(result_shapes[0]['Copper_dict'], {'present': [2003, 2004]})
-
-        # TODO: These tests wer broken by PR #171 - see bug issue #187
-        # self.assertEqual(result_shapes[0]['Government Restrictions on Public Proselytizings'], 'absent')
-        # self.assertEqual(result_shapes[0]['Government Restrictions on Public Proselytizings_dict'], {'absent': [2002, 2003]})
+        self.assertEqual(result_shapes[0]['Government Restrictions on Public Proselytizings'], 'absent')
+        self.assertEqual(result_shapes[0]['Government Restrictions on Public Proselytizings_dict'], {'absent': [2002, 2003]})
 
     def test_assign_categorical_variables_to_shapes(self):
         """Test the assign_categorical_variables_to_shapes function."""

--- a/seshat/apps/core/tests/tests.py
+++ b/seshat/apps/core/tests/tests.py
@@ -556,7 +556,7 @@ class ShapesTest(TestCase):
         self.assertEqual(result_shapes[0]['Judge'], 'present')
         self.assertEqual(result_shapes[0]['Judge_dict'], {'present': [2003, 2004]})
         self.assertEqual(result_shapes[0]['Copper'], 'present')
-        # self.assertEqual(result_shapes[0]['Copper_dict'], {'present': [2003, 2004]})
+        self.assertEqual(result_shapes[0]['Copper_dict'], {'present': [2003, 2004]})
 
         # TODO: These tests wer broken by PR #171 - see bug issue #187
         # self.assertEqual(result_shapes[0]['Government Restrictions on Public Proselytizings'], 'absent')

--- a/seshat/apps/rt/models.py
+++ b/seshat/apps/rt/models.py
@@ -21,6 +21,7 @@ from seshat.apps.accounts.models import Seshat_Expert
 ########## Beginning of tuple choices for general Models
 ABSENT_PRESENT_CHOICES = (
 ('present', 'present'),
+('uncoded', 'uncoded'),
 ('absent', 'absent'),
 ('unknown', 'unknown'),
 ('A~P', 'Transitional (Absent -> Present)'),

--- a/seshat/apps/rt/models.py
+++ b/seshat/apps/rt/models.py
@@ -16,17 +16,9 @@ from django.utils import translation
 from ..core.models import SeshatCommon, Certainty, Tags, Section, Subsection, Religion
 from seshat.apps.accounts.models import Seshat_Expert
 
-
+from seshat.apps.sc.models import ABSENT_PRESENT_CHOICES
 
 ########## Beginning of tuple choices for general Models
-ABSENT_PRESENT_CHOICES = (
-('present', 'present'),
-('uncoded', 'uncoded'),
-('absent', 'absent'),
-('unknown', 'unknown'),
-('A~P', 'Transitional (Absent -> Present)'),
-('P~A', 'Transitional (Present -> Absent)'),
-)
 
 FREQUENCY_CHOICES = (
 ('never', 'never (absent)'),

--- a/seshat/apps/wf/models.py
+++ b/seshat/apps/wf/models.py
@@ -17,21 +17,12 @@ from django.utils import translation
 from ..core.models import SeshatCommon, Certainty, Tags, Section, Subsection
 from seshat.apps.accounts.models import Seshat_Expert
 
+from seshat.apps.sc.models import ABSENT_PRESENT_CHOICES
+
 
 ########## End of Model Imports
 
 ########## Beginning of tuple choices for general Models
-ABSENT_PRESENT_CHOICES = (
-('present', 'present'),
-('uncoded', 'uncoded'),
-('absent', 'absent'),
-('unknown', 'unknown'),
-('A~P', 'Transitional (Absent -> Present)'),
-('P~A', 'Transitional (Present -> Absent)'),
-)
-
-
-
 
 ########## TUPLE CHOICES THAT ARE THE SAME 
 

--- a/seshat/apps/wf/models.py
+++ b/seshat/apps/wf/models.py
@@ -23,6 +23,7 @@ from seshat.apps.accounts.models import Seshat_Expert
 ########## Beginning of tuple choices for general Models
 ABSENT_PRESENT_CHOICES = (
 ('present', 'present'),
+('uncoded', 'uncoded'),
 ('absent', 'absent'),
 ('unknown', 'unknown'),
 ('A~P', 'Transitional (Absent -> Present)'),


### PR DESCRIPTION
Closes #187 

@MajidBenam I figured out a problem was that the `ABSENT_PRESENT_CHOICES` had been updated in `sc` but not in `wf` or `rt`, so I have now updated the `wf` and `rt` models to import `ABSENT_PRESENT_CHOICES` from `sc` so it is only maintained in one file. This fixes the issue of Warfare variables not showing up on the world map.

The only other change in this PR is simply an additional check to my test for the `assign_variables_to_shapes` function which I use for the world map.