### PR TITLE
Reintroduce selected date to polity page map

### DIFF
--- a/seshat/apps/core/templates/core/polity_map.html
+++ b/seshat/apps/core/templates/core/polity_map.html
@@ -100,7 +100,7 @@
             <div style="width: 20%">
                 <fieldset>
 		            <div>
-                        <h2 class="h2 text-teal federicka-medium">
+                        <h2 class="h2 text-dark federicka-medium">
                             <span>Displayed: </span>
                             <span id="sliderDate"></span>
                         </h2>

--- a/seshat/apps/core/templates/core/polity_map.html
+++ b/seshat/apps/core/templates/core/polity_map.html
@@ -100,6 +100,10 @@
             <div style="width: 20%">
                 <fieldset>
 		            <div>
+                        <h2 class="h2 text-teal federicka-medium">
+                            <span>Displayed: </span>
+                            <span id="sliderDate"></span>
+                        </h2>
                         <p><a href="../cliopatria">Learn more about this dataset.</a></p>
                         <label for="switchPolitiesComponents">Display:</label>
                         <select name="switchPolitiesComponents" id="switchPolitiesComponents" onchange="plotPolities()">


### PR DESCRIPTION
Fixes #198 

@MajidBenam @Zsajk what do you think about this solution? It fixes the bug introduced - you can now hit enter to set the year, and it reintroduces the selected date year in the top left, but makes it clearer that this is the displayed year on the map:

<img width="1338" alt="Screenshot 2024-12-05 at 14 53 14" src="https://github.com/user-attachments/assets/22bd8358-95c2-4fb1-8e08-a78608865e04">
