### PR TITLE
api: re-enable OrderingFilter and expose ordering_fields=['id'] for stable pagination

### DIFF
--- a/seshat/apps/seshat_api/views/_mixins.py
+++ b/seshat/apps/seshat_api/views/_mixins.py
@@ -84,7 +84,7 @@ class MixinSeshatAPISerializerNEW:
         return GeneralSerializer
 
     def get_queryset(self):
-        return self.model.objects.all()
+        return self.model.objects.all().order_by('id')
 
 class MixinSeshatAPISerializer:
     def get_serializer_class(self):
@@ -102,7 +102,7 @@ class MixinSeshatAPISerializer:
         return GeneralSerializer
 
     def get_queryset(self):
-        return self.model.objects.all()
+        return self.model.objects.all().order_by('id')
     
 class MixinLuxuryGoodsSeshatAPISerializer:
     def get_serializer_class(self):
@@ -112,7 +112,7 @@ class MixinLuxuryGoodsSeshatAPISerializer:
         return GeneralLuxuryGoodsSerializer
 
     def get_queryset(self):
-        return self.model.objects.all()
+        return self.model.objects.all().order_by('id')
     
 class MixinSeshatAPISerializerAllFields:
     def get_serializer_class(self):
@@ -122,7 +122,7 @@ class MixinSeshatAPISerializerAllFields:
         return GeneralAllFieldsSerializer
 
     def get_queryset(self):
-        return self.model.objects.all()
+        return self.model.objects.all().order_by('id')
     
 class MixinSeshatPolity:
     def get_serializer_class(self):
@@ -130,13 +130,13 @@ class MixinSeshatPolity:
 
         return PolityAPISerializer
     def get_queryset(self):
-        return self.model.objects.all()
+        return self.model.objects.all().order_by('id')
     
 
 class FilterBackends:
     filter_backends = [
         DjangoFilterBackend,
-        filters.OrderingFilter,
+        #filters.OrderingFilter,
         filters.SearchFilter,
     ]
-    ordering_fields = ['id',]
+    #ordering_fields = ['id',]

--- a/seshat/apps/seshat_api/views/_mixins.py
+++ b/seshat/apps/seshat_api/views/_mixins.py
@@ -136,7 +136,7 @@ class MixinSeshatPolity:
 class FilterBackends:
     filter_backends = [
         DjangoFilterBackend,
-        #filters.OrderingFilter,
+        filters.OrderingFilter,
         filters.SearchFilter,
     ]
-    #ordering_fields = ['id',]
+    ordering_fields = ['id',]


### PR DESCRIPTION

Page-number pagination on several API list endpoints can return duplicate and missing rows because ordering is not deterministic (OrderingFilter was disabled and the queryset doesn’t enforce an order).


/api/sc/polity-territories/?page_size=100: API count = 606; fetched rows = 606; unique ids = 587 (19 duplicates). Duplicate ids vary across runs.



Change
Re-enable DRF filters.OrderingFilter and expose ordering_fields=['id']. This allows clients to request ?ordering=id, yielding deterministic, indexed ordering.