### PR TITLE
Use exact match on polity__name in SeshatCommonFilter/ Name change to "polity__name" vs "polity__new_name"

### DIFF
--- a/seshat/apps/seshat_api/filters/_mixins.py
+++ b/seshat/apps/seshat_api/filters/_mixins.py
@@ -34,7 +34,7 @@ class SeshatCommonFilter:
             is_uncertain=["exact"],
             #expert_reviewed=["exact"],
             #drb_reviewed=["exact"],
-            polity__new_name=["icontains"],
+            polity__name=["exact"],
             polity__long_name=["icontains"],
             #polity__polity_tag=["exact"],
             #polity__home_nga__name=["icontains"],


### PR DESCRIPTION
Switch filter from
polity__new_name__icontains to polity__name (exact).


API responses already return the canonical slug as polity.name
(e.g. "de_empire_2").
Using that same field for filtering is:

Consistent: users can copy the slug they see in the JSON.

Precise : avoids accidental substring matches.

Before:

GET /api/sc/examination-systems/?polity__new_name__icontains=at_habsburg_2


After:

GET /api/sc/examination-systems/?polity__name=at_habsburg_2
