### PR TITLE
Add polity instability source and batch filters

### DIFF
--- a/seshat/apps/core/templates/core/polity/polity_detail.html
+++ b/seshat/apps/core/templates/core/polity/polity_detail.html
@@ -2480,6 +2480,47 @@
                 </div>
 
             </div>
+
+            {% if show_instability_batch_filter or show_instability_source_filter %}
+                {% if 'core.add_capital' in user.get_all_permissions  or user|in_group:"Chief Seshat External Experts" %}
+                    <form method="get" action="{% url 'polity-detail-main' object.id %}#instability_event_var" class="row align-items-end g-2 py-1">
+                        {% if show_instability_source_filter %}
+                            <div class="col-auto">
+                                <label for="instability_source" class="text-secondary small mb-0">Source</label>
+                                <select name="source" id="instability_source" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                                    <option value="">All</option>
+                                    <option value="llm" {% if selected_instability_source == "llm" %}selected{% endif %}>LLM</option>
+                                    <option value="manual" {% if selected_instability_source == "manual" %}selected{% endif %}>Manual</option>
+                                </select>
+                            </div>
+                        {% endif %}
+                        {% if show_instability_batch_filter %}
+                            <div class="col-auto">
+                                <label for="selected_batch" class="text-secondary small mb-0">LLM Batch</label>
+                                <select name="selected_batch" id="selected_batch" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                                    <option value="">All</option>
+                                    <option value="Batch 1" {% if selected_instability_batch == "Batch 1" %}selected{% endif %}>Batch 1</option>
+                                    <option value="Batch 2" {% if selected_instability_batch == "Batch 2" %}selected{% endif %}>Batch 2</option>
+                                    <option value="Batch 3" {% if selected_instability_batch == "Batch 3" %}selected{% endif %}>Batch 3</option>
+                                    <option value="Batch 4" {% if selected_instability_batch == "Batch 4" %}selected{% endif %}>Batch 4</option>
+                                </select>
+                            </div>
+                        {% endif %}
+                        {% if selected_instability_batch or selected_instability_source %}
+                            <div class="col-auto">
+                                <a href="{% url 'polity-detail-main' object.id %}#instability_event_var" class="btn btn-outline-secondary btn-sm">Clear filters</a>
+                            </div>
+                        {% endif %}
+                    </form>
+                    {% if selected_instability_batch or selected_instability_source %}
+                    {% if not all_instability_data %}
+                        <div class="alert alert-light border text-secondary py-2" role="status">
+                            No instability events in this polity match the selected filters.
+                        </div>
+                    {% endif %}
+                    {% endif %}
+                {% endif %}
+            {% endif %}
     
             {% if all_instability_data %}
             {% for key, values in all_instability_data.items %}

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -79,7 +79,8 @@ from urllib.parse import urlparse, urlunparse, quote
 from ..general.models import Polity_research_assistant, Polity_duration, Polity_linguistic_family, Polity_language_genus, Polity_language, POLITY_LINGUISTIC_FAMILY_CHOICES, POLITY_LANGUAGE_GENUS_CHOICES, POLITY_LANGUAGE_CHOICES, Polity_religious_tradition, Polity_religion_genus, Polity_religion_family, Polity_religion, Polity_alternate_religion_genus, Polity_alternate_religion_family, Polity_alternate_religion, POLITY_RELIGION_GENUS_CHOICES, POLITY_RELIGION_FAMILY_CHOICES, POLITY_RELIGION_CHOICES
 from ..sc.models import Settlement_hierarchy, Religious_level, Military_level, Administrative_level, Polity_territory, Polity_population
 
-from ..crisisdb.models import Power_transition
+from ..crisisdb.models import Instability_event, Power_transition
+from ..crisisdb.instability_filters import get_polity_instability_queryset
 
 from .models import Citation, Polity, Section, Subsection, Variablehierarchy, Reference, SeshatComment, SeshatCommentPart, Nga, Ngapolityrel, Capital, Seshat_region, Macro_region, Cliopatria, GADMCountries, GADMProvinces, SeshatCommon, ScpThroughCtn, SeshatPrivateComment, SeshatPrivateCommentPart, Religion, HabitationSite, CityPolityRelation
 
@@ -3099,6 +3100,17 @@ class PolityDetailView(SuccessMessageMixin, generic.DetailView):
         elif 'new_name' in self.kwargs:
             my_pol = Polity.objects.get(new_name=self.kwargs['new_name'])
             context['pk'] = my_pol.pk
+        selected_instability_batch = self.request.GET.get("selected_batch", "")
+        selected_instability_source = self.request.GET.get("source", "")
+        if selected_instability_source not in {
+            Instability_event.Source.LLM,
+            Instability_event.Source.MANUAL,
+        }:
+            selected_instability_source = ""
+        context["selected_instability_batch"] = selected_instability_batch
+        context["selected_instability_source"] = selected_instability_source
+        context["show_instability_source_filter"] = bool(selected_instability_source)
+        context["show_instability_batch_filter"] = bool(selected_instability_batch)
         try:
             context["all_data"] = get_all_data_for_a_polity(self.object.pk, "crisisdb") 
             context["all_general_data"], context["has_any_general_data"] = get_all_general_data_for_a_polity(self.object.pk)
@@ -3108,7 +3120,22 @@ class PolityDetailView(SuccessMessageMixin, generic.DetailView):
             context["all_rt_data"], context["has_any_rt_data"] = get_all_rt_data_for_a_polity(self.request, self.object.pk)
             context["all_crisis_cases_data"] = get_all_crisis_cases_data_for_a_polity(self.object.pk)
             context["all_power_transitions_data"] = get_all_power_transitions_data_for_a_polity(self.object.pk)
-            context["all_instability_data"] = get_all_instability_data_for_a_polity(self.object.pk)
+            context["all_instability_data"] = get_all_instability_data_for_a_polity(
+                self.object.pk,
+                selected_source=selected_instability_source,
+                selected_batch=selected_instability_batch,
+            )
+            context["show_instability_source_filter"] = bool(
+                selected_instability_source
+                or get_polity_instability_queryset(
+                    self.object.pk,
+                    selected_source=Instability_event.Source.MANUAL,
+                ).exists()
+            )
+            context["show_instability_batch_filter"] = bool(
+                selected_instability_source != Instability_event.Source.MANUAL
+                and (context["all_instability_data"] or selected_instability_batch)
+            )
             all_Ras = Polity_research_assistant.objects.filter(polity_id=self.object.pk)
             all_Ras_ids = all_Ras.values_list('polity_ra_id', flat=True)
             experts = Seshat_Expert.objects.filter(id__in=all_Ras_ids)

--- a/seshat/apps/crisisdb/instability_filters.py
+++ b/seshat/apps/crisisdb/instability_filters.py
@@ -81,6 +81,22 @@ def apply_instability_batch_filter(queryset, selected_batch):
     return queryset
 
 
+def get_polity_instability_queryset(polity_id, selected_source=None, selected_batch=None):
+    queryset = Instability_event.objects.filter(
+        polity__id=polity_id,
+        polity__unreliable_instability_events=False,
+    ).order_by("year_from")
+
+    if selected_source in {Instability_event.Source.LLM, Instability_event.Source.MANUAL}:
+        queryset = queryset.filter(source=selected_source)
+
+    if selected_batch and selected_source != Instability_event.Source.MANUAL:
+        queryset = queryset.filter(source=Instability_event.Source.LLM)
+        queryset = apply_instability_batch_filter(queryset, selected_batch)
+
+    return queryset
+
+
 def get_selected_instability_source(request):
     selected_source = request.GET.get("source")
     if selected_source in {Instability_event.Source.LLM, Instability_event.Source.MANUAL}:

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -1,10 +1,14 @@
+import datetime
+
 from django.contrib.auth.models import Permission, User
 from django.test import TestCase
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import timezone
 
 from seshat.apps.accounts.models import Seshat_Expert
 from seshat.apps.core.models import Polity, SeshatComment
+from seshat.apps.crisisdb.instability_filters import get_polity_instability_queryset
 from seshat.apps.crisisdb.models import (
     Check_choice,
     Instability_event,
@@ -258,6 +262,126 @@ class InstabilityCreateViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(response.context["object_list"]), [manual_event])
+
+    def test_polity_instability_queryset_filters_by_batch(self):
+        polity = Polity.objects.create(
+            name="polity_batch_filter",
+            new_name="polity_batch_filter",
+            long_name="Polity Batch Filter",
+            start_year=100,
+            end_year=200,
+        )
+        batch_one_event = Instability_event.objects.create(
+            polity=polity,
+            name="Batch One Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        batch_four_event = Instability_event.objects.create(
+            polity=polity,
+            name="Batch Four Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        manual_event = Instability_event.objects.create(
+            polity=polity,
+            name="Manual Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=154,
+            year_to=155,
+        )
+        batch_one_date = timezone.make_aware(datetime.datetime(2025, 3, 1))
+        batch_four_date = timezone.make_aware(datetime.datetime(2026, 3, 2))
+        Instability_event.objects.filter(pk=batch_one_event.pk).update(created_date=batch_one_date)
+        Instability_event.objects.filter(pk=manual_event.pk).update(created_date=batch_one_date)
+        Instability_event.objects.filter(pk=batch_four_event.pk).update(created_date=batch_four_date)
+
+        unfiltered_events = list(get_polity_instability_queryset(polity.id))
+        batch_one_events = list(
+            get_polity_instability_queryset(polity.id, selected_batch="Batch 1")
+        )
+        manual_events = list(
+            get_polity_instability_queryset(
+                polity.id,
+                selected_source=Instability_event.Source.MANUAL,
+                selected_batch="Batch 1",
+            )
+        )
+        llm_batch_one_events = list(
+            get_polity_instability_queryset(
+                polity.id,
+                selected_source=Instability_event.Source.LLM,
+                selected_batch="Batch 1",
+            )
+        )
+
+        self.assertEqual(unfiltered_events, [batch_one_event, batch_four_event, manual_event])
+        self.assertEqual(batch_one_events, [batch_one_event])
+        self.assertEqual(manual_events, [manual_event])
+        self.assertEqual(llm_batch_one_events, [batch_one_event])
+
+    def test_polity_detail_instability_batch_filter_renders(self):
+        polity = Polity.objects.create(
+            name="polity_detail_batch_filter",
+            new_name="polity_detail_batch_filter",
+            long_name="Polity Detail Batch Filter",
+            start_year=100,
+            end_year=200,
+        )
+        batch_one_event = Instability_event.objects.create(
+            polity=polity,
+            name="Polity Detail Batch One Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        batch_four_event = Instability_event.objects.create(
+            polity=polity,
+            name="Polity Detail Batch Four Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        manual_event = Instability_event.objects.create(
+            polity=polity,
+            name="Polity Detail Manual Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=154,
+            year_to=155,
+        )
+        Instability_event.objects.filter(pk=batch_one_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2025, 3, 1))
+        )
+        Instability_event.objects.filter(pk=batch_four_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2026, 3, 2))
+        )
+        Instability_event.objects.filter(pk=manual_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2025, 3, 1))
+        )
+
+        response = self.client.get(
+            reverse("polity-detail-main", args=[polity.id]),
+            {"selected_batch": "Batch 1"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Source")
+        self.assertContains(response, "LLM Batch")
+        self.assertContains(response, "Polity Detail Batch One Event")
+        self.assertNotContains(response, "Polity Detail Batch Four Event")
+        self.assertNotContains(response, "Polity Detail Manual Event")
+
+        manual_response = self.client.get(
+            reverse("polity-detail-main", args=[polity.id]),
+            {"source": "manual", "selected_batch": "Batch 1"},
+        )
+
+        self.assertEqual(manual_response.status_code, 200)
+        self.assertContains(manual_response, "Polity Detail Manual Event")
+        self.assertNotContains(manual_response, "Polity Detail Batch One Event")
+        self.assertNotContains(manual_response, "LLM Batch")
 
     def test_source_filter_scopes_filter_options_and_chip(self):
         manual_polity = Polity.objects.create(

--- a/seshat/utils/utils.py
+++ b/seshat/utils/utils.py
@@ -3,6 +3,7 @@ from seshat.apps.core.models import Polity, Variablehierarchy, Section, Subsecti
 import django.apps
 import pprint
 from seshat.apps.crisisdb.models import Crisis_consequence, Power_transition, Human_sacrifice, Instability_event
+from seshat.apps.crisisdb.instability_filters import get_polity_instability_queryset
 
 from seshat.apps.general.models import Polity_degree_of_centralization, Polity_suprapolity_relations
 # from seshat.apps.crisisdb.models import Us_location, Us_violence_subtype, Us_violence_data_source, Us_violence, External_conflict, Internal_conflict, External_conflict_side, Agricultural_population, Arable_land, Arable_land_per_farmer, Gross_grain_shared_per_agricultural_population, Net_grain_shared_per_agricultural_population, Surplus, Military_expense, Silver_inflow, Silver_stock, Total_population, Gdp_per_capita, Drought_event, Locust_event, Socioeconomic_turmoil_event, Crop_failure_event, Famine_event, Disease_outbreak
@@ -913,12 +914,13 @@ def get_all_power_transitions_data_for_a_polity(polity_id):
     #print(a_data_dic)
     return a_data_dic
 
-def get_all_instability_data_for_a_polity(polity_id):
+def get_all_instability_data_for_a_polity(polity_id, selected_source=None, selected_batch=None):
     a_data_dic = {}
-    my_data = Instability_event.objects.filter(
-        polity__id=polity_id,
-        polity__unreliable_instability_events=False
-    ).order_by('year_from')
+    my_data = get_polity_instability_queryset(
+        polity_id,
+        selected_source=selected_source,
+        selected_batch=selected_batch,
+    )
 
     if my_data:
         #a_data_dic["power_transitions"] = my_data
@@ -1235,8 +1237,6 @@ def polity_detail_data_collector(polity_id):
             final_response = {}
     #print(final_response)
     return final_response
-
-
 
 
 


### PR DESCRIPTION
Adds Source and LLM Batch filters to the instability events section on polity detail pages.

The implementation reuses shared instability filtering logic via get_polity_instability_queryset(...), so the existing polity-page row rendering, add/action controls, and expert review UI remain unchanged.


