### PR TITLE
Improve instability event filtering and search

### DIFF
--- a/seshat/apps/core/filter_tokens.py
+++ b/seshat/apps/core/filter_tokens.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from typing import Iterable
+
+
+TOKEN_SEPARATOR = ":"
+
+
+@dataclass(frozen=True)
+class FilterTokenOption:
+    """Reusable grouped option shape for AJAX-backed filter pickers."""
+
+    kind: str
+    value: str
+    label: str
+    group: str
+    meta: str = ""
+
+    @property
+    def token_id(self):
+        return make_filter_token(self.kind, self.value)
+
+    def as_select2_result(self):
+        result = {
+            "id": self.token_id,
+            "text": self.label,
+            "kind": self.kind,
+            "value": self.value,
+        }
+        if self.meta:
+            result["meta"] = self.meta
+        return result
+
+
+def make_filter_token(kind, value):
+    return f"{kind}{TOKEN_SEPARATOR}{value}"
+
+
+def parse_filter_token(token_id):
+    kind, separator, value = str(token_id).partition(TOKEN_SEPARATOR)
+    if not separator or not kind or not value:
+        return None, None
+    return kind, value
+
+
+def build_grouped_token_response(options: Iterable[FilterTokenOption]):
+    grouped_results = {}
+    for option in options:
+        grouped_results.setdefault(option.group, []).append(option.as_select2_result())
+
+    return {
+        "results": [
+            {"text": group, "children": children}
+            for group, children in grouped_results.items()
+            if children
+        ]
+    }

--- a/seshat/apps/core/filter_tokens.py
+++ b/seshat/apps/core/filter_tokens.py
@@ -62,6 +62,14 @@ def get_search_terms(search_query):
     return normalize_search_text(search_query).split()
 
 
+def parse_integer_filter_value(value):
+    """Return a normalized integer filter value, or None for invalid input."""
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
 def build_term_search_query(search_query, fields):
     """Build a Q object requiring every search term to match at least one field."""
     terms = get_search_terms(search_query)

--- a/seshat/apps/core/filter_tokens.py
+++ b/seshat/apps/core/filter_tokens.py
@@ -1,8 +1,13 @@
+import re
+import unicodedata
 from dataclasses import dataclass
 from typing import Iterable
 
+from django.db.models import Q
+
 
 TOKEN_SEPARATOR = ":"
+SEARCH_TERM_PATTERN = re.compile(r"[\w]+")
 
 
 @dataclass(frozen=True)
@@ -42,15 +47,64 @@ def parse_filter_token(token_id):
     return kind, value
 
 
-def build_grouped_token_response(options: Iterable[FilterTokenOption]):
+def normalize_search_text(value):
+    """Normalize user-entered filter text for case/diacritic-insensitive matching."""
+    normalized = unicodedata.normalize("NFKD", str(value or ""))
+    ascii_text = "".join(
+        character
+        for character in normalized
+        if not unicodedata.combining(character)
+    )
+    return " ".join(SEARCH_TERM_PATTERN.findall(ascii_text.lower()))
+
+
+def get_search_terms(search_query):
+    return normalize_search_text(search_query).split()
+
+
+def build_term_search_query(search_query, fields):
+    """Build a Q object requiring every search term to match at least one field."""
+    terms = get_search_terms(search_query)
+    if not terms:
+        return Q()
+
+    combined_query = Q()
+    for term in terms:
+        term_query = Q()
+        for field in fields:
+            term_query |= Q(**{f"{field}__icontains": term})
+        combined_query &= term_query
+    return combined_query
+
+
+def build_grouped_token_response(options: Iterable[FilterTokenOption], group_order=None):
+    """Return Select2 grouped results, optionally honoring an explicit group order."""
     grouped_results = {}
+    inserted_groups = []
     for option in options:
-        grouped_results.setdefault(option.group, []).append(option.as_select2_result())
+        if option.group not in grouped_results:
+            grouped_results[option.group] = []
+            inserted_groups.append(option.group)
+        grouped_results[option.group].append(option.as_select2_result())
+
+    ordered_groups = []
+    seen_groups = set()
+    for group in group_order or ():
+        if (
+            group not in seen_groups
+            and group in grouped_results
+            and grouped_results[group]
+        ):
+            ordered_groups.append(group)
+            seen_groups.add(group)
+    for group in inserted_groups:
+        if group not in seen_groups and grouped_results[group]:
+            ordered_groups.append(group)
 
     return {
         "results": [
             {"text": group, "children": children}
-            for group, children in grouped_results.items()
-            if children
+            for group in ordered_groups
+            for children in (grouped_results[group],)
         ]
     }

--- a/seshat/apps/core/templates/core/list_base_for_new_approach.html
+++ b/seshat/apps/core/templates/core/list_base_for_new_approach.html
@@ -334,157 +334,34 @@
     {% block secondary_description %}
     {% endblock secondary_description %}
 
+{% if var_name_display == 'Instability Event' %}
+    {% include "core/partials/_instability_list_filters.html" %}
+{% else %}
 <div class="border border-secondary rounded px-3 pt-3 mb-2" style="background: #fffdf2;">
     <form method="get" class="row g-2 mb-3">
         <div class="col-12 d-flex flex-wrap justify-content-between align-items-start gap-2 pb-1">
             <div>
-                <strong class="text-dark">
-                    {% if var_name_display == 'Instability Event' %}
-                        Filter Instability Events
-                    {% else %}
-                        Filter Records
-                    {% endif %}
-                </strong>
+                <strong class="text-dark">Filter Records</strong>
                 <div class="small text-secondary">
-                    {% if var_name_display == 'Instability Event' %}
-                        Combine multiple polities, categories, and review signals in one pass.
-                    {% else %}
-                        Refine the list with focused filters and year bounds.
-                    {% endif %}
+                    Refine the list with focused filters and year bounds.
                 </div>
             </div>
             <div class="small text-secondary">
-                {% if var_name_display == 'Instability Event' %}
-                    Select multiple values where needed, then click <span class="fw-semibold text-dark">Apply Filters</span>.
-                {% else %}
-                    Adjust the filters, then click <span class="fw-semibold text-dark">Apply Filters</span>.
-                {% endif %}
+                Adjust the filters, then click <span class="fw-semibold text-dark">Apply Filters</span>.
             </div>
         </div>
 
         <div class="col-md-6 pb-2">
-            {% if var_name_display == 'Instability Event' %}
-                <label for="polity" class="text-secondary">Polities <small class="text-secondary">(matching: {{ polities|length }})</small></label>
-                <select name="polity" id="polity" class="form-select js-example-basic-multiple" multiple>
-                  {% for p in polities %}
-                    <option value="{{ p.id }}" {% if p.id|stringformat:"s" in selected_polity_ids %}selected{% endif %}>
-                        {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}] · {{ p.event_count }}
-                    </option>
-                  {% endfor %}
-                </select>
-            {% else %}
-                <label for="polity" class="text-secondary">Polity <small class="text-secondary">(total: {{ polities|length }})</small></label>
-                <select name="polity" id="polity" class="form-select js-example-basic-single">
-                  <option value="">All</option>
-                  {% for p in polities %}
-                    <option value="{{ p.id }}" {% if request.GET.polity == p.id|stringformat:"s" %}selected{% endif %}>
-                        {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}]
-                    </option>
-                  {% endfor %}
-                </select>
-            {% endif %}
-        </div>
-
-        {% if var_name_display == 'Instability Event' %}
-        <div class="col-md-6 pb-2">
-            <label for="macro_event" class="text-secondary">Umbrella Events</label>
-            <select name="macro_event" id="macro_event" class="form-select js-example-basic-multiple" multiple>
-              {% for event, count in macro_events_with_counts %}
-                <option value="{{ event }}" {% if event in selected_macro_events %}selected{% endif %}>
-                   {{ event }} · {{ count }}
-                </option>
-              {% endfor %}
-            </select>
-        </div>
-
-        <div class="col-md-2 pb-2">
-            <label for="source" class="text-secondary">Source</label>
-            <select name="source" id="source" class="form-select js-example-basic-single">
+            <label for="polity" class="text-secondary">Polity <small class="text-secondary">(total: {{ polities|length }})</small></label>
+            <select name="polity" id="polity" class="form-select js-example-basic-single">
               <option value="">All</option>
-              <option value="llm" {% if selected_source == "llm" %}selected{% endif %}>LLM</option>
-              <option value="manual" {% if selected_source == "manual" %}selected{% endif %}>Manual</option>
-            </select>
-        </div>
-
-        <div class="col-md-2 pb-2">
-            <label for="row_quality" class="text-secondary">Row Quality</label>
-            <select name="row_quality" id="row_quality" class="form-select js-example-basic-single">
-              <option value="">All rows</option>
-              <option value="good" {% if selected_row_quality == "good" %}selected{% endif %}>Good rows only</option>
-            </select>
-        </div>
-
-        <div class="col-md-2 pb-2">
-            <label for="is_macro_event" class="text-secondary">Macroevent Record</label>
-            <select name="is_macro_event" id="is_macro_event" class="form-select js-example-basic-single">
-              <option value="">All</option>
-              <option value="true" {% if selected_is_macro_event == "true" %}selected{% endif %}>True</option>
-              <option value="false" {% if selected_is_macro_event == "false" %}selected{% endif %}>False</option>
-            </select>
-        </div>
-
-        {% if show_llm_batch_filter %}
-        <div class="col-md-2 pb-2">
-            <label for="selected_batch" class="text-secondary">LLM Batch</label>
-            <select name="selected_batch" id="selected_batch" class="form-select js-example-basic-single">
-              <option value="">All</option>
-              <option value="Batch 1" {% if selected_batch == "Batch 1" %}selected{% endif %}>Batch 1</option>
-              <option value="Batch 2" {% if selected_batch == "Batch 2" %}selected{% endif %}>Batch 2</option>
-              <option value="Batch 3" {% if selected_batch == "Batch 3" %}selected{% endif %}>Batch 3</option>
-              <option value="Batch 4" {% if selected_batch == "Batch 4" %}selected{% endif %}>Batch 4</option>
-            </select>
-        </div>
-        {% endif %}
-
-        <div class="col-md-4 pb-2">
-            <label for="inst_type_select" class="text-secondary d-block">Event Types</label>
-            <select id="inst_type_select" name="inst_type" class="form-select js-example-basic-multiple" multiple>
-              {% for type in instability_types %}
-                <option value="{{ type.id }}" {% if type.id|stringformat:"s" in selected_inst_type_ids %}selected{% endif %}>
-                  {{ type.name }} · {{ type.event_count }}
+              {% for p in polities %}
+                <option value="{{ p.id }}" {% if request.GET.polity == p.id|stringformat:"s" %}selected{% endif %}>
+                    {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}]
                 </option>
               {% endfor %}
             </select>
         </div>
-
-        <div class="col-md-4 pb-2">
-            <label for="ra_check_select" class="text-secondary d-block">Researcher Checks</label>
-            <select id="ra_check_select" name="ra_check" class="form-select js-example-basic-multiple" multiple>
-              {% for check in check_choices %}
-                <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_ra_check_ids %}selected{% endif %}>
-                  {{ check.name }} · {{ check.event_count }}
-                </option>
-              {% endfor %}
-            </select>
-        </div>
-
-        <div class="col-md-4 pb-2">
-            <label for="inst_intensity_select" class="text-secondary">Intensity</label>
-            <select id="inst_intensity_select" name="inst_intensity" class="form-select js-example-basic-multiple" multiple>
-              {% for val, label, count in inst_intensity_filter_choices %}
-                <option value="{{ val }}" {% if val in selected_inst_intensity_values %}selected{% endif %}>
-                  {{ label }} · {{ count }}
-                </option>
-              {% endfor %}
-            </select>
-        </div>
-
-        <div class="col-md-4 pb-2">
-            <label for="inst_extent_select" class="text-secondary">Extent</label>
-            <select id="inst_extent_select" name="inst_extent" class="form-select js-example-basic-multiple" multiple>
-              {% for val, label, count in inst_extent_filter_choices %}
-                <option value="{{ val }}" {% if val in selected_inst_extent_values %}selected{% endif %}>
-                  {{ label }} · {{ count }}
-                </option>
-              {% endfor %}
-            </select>
-        </div>
-
-        <div class="col-md-4 pb-2">
-            <label for="searched_name" class="text-secondary">Event Name</label>
-            <input type="text" name="searched_name" id="searched_name" class="form-control" value="{{ name_query }}" placeholder="Search the coded event name">
-        </div>
-        {% endif %}
 
         <div class="col-md-2 pb-2">
             <label class="text-secondary" for="year_from_min">Start Year</label>
@@ -503,14 +380,8 @@
             <a href="?" class="btn btn-outline-danger fw-semibold text-nowrap">Clear All</a>
         </div>
 
-        {% if var_name_display == 'Instability Event' %}
-        <div class="col-12 small text-secondary pt-1">
-            <span class="fw-semibold text-dark">Good rows only</span> currently hides rows tagged as <span class="text-dark">Bad Row</span>, <span class="text-dark">Duplicate</span>, <span class="text-dark">Not Instability Event</span>, or <span class="text-dark">External Event</span>.
-        </div>
-        {% endif %}
-
         <div class="col-12 align-self-end pb-0 mb-0">
-          {% if selected_polity_ids or request.GET.polity or selected_source or selected_batch or selected_inst_type_ids or selected_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or name_query or selected_macro_events or selected_is_macro_event or selected_row_quality or request.GET.year_from_min or request.GET.year_to_max %}
+          {% if request.GET.polity or request.GET.year_from_min or request.GET.year_to_max %}
 
           <div class="py-1 px-0 d-inline-block">
             <strong class="pb-2">Filters applied:</strong>
@@ -529,16 +400,7 @@
                 </li>
               {% endif %}
 
-              {% if var_name_display == 'Instability Event' %}
-                {% for p in polities %}
-                  {% if p.id|stringformat:"s" in selected_polity_ids %}
-                    <li class="list-inline-item px-2 mb-1 rounded bg-success-light text-dark">
-                      <small class="fw-light">Polity:</small> <span class="fw-bold">{{ p.long_name }}</span> ({{ p.new_name }})
-                      <a href="{% query_without request 'polity' p.id|stringformat:'s' %}" class="text-dark text-decoration-none ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                    </li>
-                  {% endif %}
-                {% endfor %}
-              {% elif request.GET.polity %}
+              {% if request.GET.polity %}
                 {% with request.GET.polity as selected_polity_id %}
                   {% for p in polities %}
                     {% if p.id|stringformat:"s" == selected_polity_id %}
@@ -551,83 +413,6 @@
                 {% endwith %}
               {% endif %}
 
-              {% for selected_macro_event in selected_macro_events %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
-                  <small class="fw-light">Umbrella Event:</small> <span class="fw-bold">{{ selected_macro_event }}</span>
-                  <a href="{% query_without request 'macro_event' selected_macro_event %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endfor %}
-
-              {% if selected_is_macro_event %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
-                  <small class="fw-light">Macroevent:</small> <span class="fw-bold">{{ selected_is_macro_event|title }}</span>
-                  <a href="?{% query_transform request is_macro_event=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endif %}
-
-              {% if selected_row_quality == "good" %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-colorful text-dark">
-                  <small class="fw-light">Row Quality:</small> <span class="fw-bold">Good rows only</span>
-                  <a href="?{% query_transform request row_quality=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endif %}
-
-              {% if name_query %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
-                  <small class="fw-light">Event Name:</small> <span class="fw-bold">{{ name_query }}</span>
-                  <a href="?{% query_transform request searched_name=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endif %}
-
-              {% for val, label in INST_INTENSITY_CHOICES %}
-                {% if val in selected_inst_intensity_values %}
-                  <li class="list-inline-item px-2 mb-1 rounded bg-danger-light text-dark">
-                    <small class="fw-light">Intensity:</small> <span class="fw-bold">{{ label }}</span>
-                    <a href="{% query_without request 'inst_intensity' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                  </li>
-                {% endif %}
-              {% endfor %}
-
-              {% for val, label in INST_EXTENT_CHOICES %}
-                {% if val in selected_inst_extent_values %}
-                  <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
-                    <small class="fw-light">Extent:</small> <span class="fw-bold">{{ label }}</span>
-                    <a href="{% query_without request 'inst_extent' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                  </li>
-                {% endif %}
-              {% endfor %}
-
-              {% for type in instability_types %}
-                {% if type.id|stringformat:"s" in selected_inst_type_ids %}
-                  <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
-                    <small class="fw-light">Type:</small> <span class="fw-bold">{{ type.name }}</span>
-                    <a href="{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                  </li>
-                {% endif %}
-              {% endfor %}
-
-              {% for check in check_choices %}
-                {% if check.id|stringformat:"s" in selected_ra_check_ids %}
-                  <li class="list-inline-item px-2 mb-1 rounded bg-violet-light text-dark">
-                    <small class="fw-light">RA Check:</small> <span class="fw-bold">{{ check.name }}</span>
-                    <a href="{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                  </li>
-                {% endif %}
-              {% endfor %}
-
-              {% if selected_source %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
-                  <small class="fw-light">Source:</small> <span class="fw-bold">{{ selected_source|title }}</span>
-                  <a href="?{% query_transform request source=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endif %}
-
-              {% if selected_batch and show_llm_batch_filter %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
-                  <small class="fw-light">LLM Batch:</small> <span class="fw-bold">{{ selected_batch }}</span>
-                  <a href="?{% query_transform request selected_batch=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endif %}
             </ul>
           </div>
           {% endif %}
@@ -636,6 +421,7 @@
 
       
 </div>
+{% endif %}
 
     <div class="table-container pb-3">
               

--- a/seshat/apps/core/templates/core/list_base_for_new_approach.html
+++ b/seshat/apps/core/templates/core/list_base_for_new_approach.html
@@ -334,285 +334,302 @@
     {% block secondary_description %}
     {% endblock secondary_description %}
 
-<div class="border border-secondary rounded px-3 pt-2 mb-2" style="background: #fffdf2;">
-    <form method="get" class="row mb-3">
-        <div class="col-md-12 row">
-            <div class="col-md-6 pb-2">
-                <label for="polity" class="text-secondary">Polity <small class="text-secondary"> (total: {{polities|length}})</small></label>
-                <br>
-                <select name="polity" id="polity" class="form-select js-example-basic-single "
-                        onchange="this.form.submit()">
-                  <option value="">All</option>
-                  {% for p in polities %}
-                    <option value="{{ p.id }}" {% if request.GET.polity == p.id|stringformat:"s" %}selected{% endif %} >
-                        {{ p.long_name }} ({{ p.new_name }}) &nbsp; &nbsp; [{{ p.formatted_years_text }}]
-                    </option>
-                  {% endfor %}
-                </select>
-              
-                {% comment %} preserve other filters with hidden fields {% endcomment %}
-                {% for key, value in request.GET.items %}
-                  {% if key != 'polity' %}
-                    <input type="hidden" name="{{ key }}" value="{{ value }}">
-                  {% endif %}
-                {% endfor %}
-            </div>
-            {% if var_name_display == 'Instability Event' %}
-            <div class="col-md-4 pb-2">
-                <label for="macro_event" class="text-secondary">Umbrella Event:</label>
-                <br>
-                <select name="macro_event" id="macro_event"  class="form-select js-example-basic-single " onchange="this.form.submit()">
-                  <option value="">All</option>
-                  {% for event, count in macro_events_with_counts %}
-                    <option value="{{ event }}" {% if event == selected_macro %}selected{% endif %}>
-                       {{ event }} (#{{ count }} Events)
-
-                    </option>
-                  {% endfor %}
-                </select>
-            </div>
-            <div class="col-md-2 pb-2">
-                <label for="is_macro_event" class="text-secondary">Macroevent:</label>
-                <br>
-                <select name="is_macro_event" id="is_macro_event" class="form-select js-example-basic-single" onchange="this.form.submit()">
-                  <option value="">All</option>
-                  <option value="true" {% if selected_is_macro_event == "true" %}selected{% endif %}>True</option>
-                  <option value="false" {% if selected_is_macro_event == "false" %}selected{% endif %}>False</option>
-                </select>
-            </div>
-            <div class="col-md-2 pb-2">
-                <label for="searched_name" class="text-secondary">Event Name:</label>
-                <input type="text" name="searched_name" id="searched_name" class="form-control" value="{{ name_query }}">
-            </div>
-
-
-            <div class="col-md-4 pb-2">
-                <label class="text-secondary">Intensity</label>
-                <select name="inst_intensity" class="form-select" onchange="this.form.submit()">
-                  <option value="">All</option>
-                  {% for val, label in INST_INTENSITY_CHOICES %}
-                    <option value="{{ val }}" {% if request.GET.inst_intensity == val %}selected{% endif %}>{{ label }}</option>
-                  {% endfor %}
-                </select>
-              </div>
-
-            <div class="col-md-5 pb-2">
-                <label class="text-secondary">Extent</label>
-                <select name="inst_extent" class="form-select" onchange="this.form.submit()">
-                  <option value="">All</option>
-                  {% for val, label in INST_EXTENT_CHOICES %}
-                    <option value="{{ val }}" {% if request.GET.inst_extent == val %}selected{% endif %}>{{ label }}</option>
-                  {% endfor %}
-                </select>
-              </div>
-
-              {% endif %}
-
-            <div class="col-md-1 pb-2">
-              <label  class="text-secondary">Start Year</label>
-              <input type="number" name="year_from_min" class="form-control" value="{{ request.GET.year_from_min }}"> 
-            </div>
-            <div class="col-md-1 pb-2">
-              <label  class="text-secondary">End Year</label>
-              <input type="number" name="year_to_max" class="form-control" value="{{ request.GET.year_to_max }}">
-            </div>
-            {% if var_name_display == 'Instability Event' %}
-
-            <div class="col-md-2 pb-2">
-                <label for="source" class="text-secondary">Source</label>
-                <select name="source" id="source" class="form-select" onchange="this.form.submit()">
-                  <option value="">All</option>
-                  <option value="llm" {% if selected_source == "llm" %}selected{% endif %}>LLM</option>
-                  <option value="manual" {% if selected_source == "manual" %}selected{% endif %}>Manual</option>
-                </select>
-              </div>
-
-            {% if show_llm_batch_filter %}
-              <div class="col-md-1 pb-2">
-                  <label for="selected_batch" class="text-secondary">LLM Batch</label>
-                  <select name="selected_batch" id="selected_batch" class="form-select" onchange="this.form.submit()">
-                    <option value="">All</option>
-                    <option value="Batch 1" {% if selected_batch == "Batch 1" %}selected{% endif %}>Batch 1</option>
-                    <option value="Batch 2" {% if selected_batch == "Batch 2" %}selected{% endif %}>Batch 2</option>
-                    <option value="Batch 3" {% if selected_batch == "Batch 3" %}selected{% endif %}>Batch 3</option>
-                    <option value="Batch 4" {% if selected_batch == "Batch 4" %}selected{% endif %}>Batch 4</option>
-                  </select>
+<div class="border border-secondary rounded px-3 pt-3 mb-2" style="background: #fffdf2;">
+    <form method="get" class="row g-2 mb-3">
+        <div class="col-12 d-flex flex-wrap justify-content-between align-items-start gap-2 pb-1">
+            <div>
+                <strong class="text-dark">
+                    {% if var_name_display == 'Instability Event' %}
+                        Filter Instability Events
+                    {% else %}
+                        Filter Records
+                    {% endif %}
+                </strong>
+                <div class="small text-secondary">
+                    {% if var_name_display == 'Instability Event' %}
+                        Combine multiple polities, categories, and review signals in one pass.
+                    {% else %}
+                        Refine the list with focused filters and year bounds.
+                    {% endif %}
                 </div>
-            {% endif %}
-                  
-    
-              <div class="col-md-4 pb-2">
-                <label for="inst_type_select" class="text-secondary d-block">Event Types</label>
-                <select id="inst_type_select" name="inst_type" class="form-select js-example-basic-multiple" multiple onchange="this.form.submit()">
-                  {% for type in instability_types %}
-                    <option value="{{ type.id }}"
-                      {% if type.id|stringformat:"s" in selected_inst_type_ids %}selected{% endif %}>
-                      {{ type.name }}
-                    </option>
-                  {% endfor %}
-                </select>
-              </div>
-
-              <div class="col-md-4 pb-2">
-                <label for="ra_check_select" class="text-secondary d-block">Researcher Checks</label>
-                <select id="ra_check_select" name="ra_check" class="form-select js-example-basic-multiple" multiple onchange="this.form.submit()">
-                    {% for check in check_choices %}
-                    <option value="{{ check.id }}"
-                      {% if check.id|stringformat:"s" in selected_ra_check_ids %}selected{% endif %}>
-                      {{ check.name }}
-                    </option>
-                  {% endfor %}
-                </select>
-              </div>
-              
-
-              
-    
-
-              
-              {% endif %}
-              <div class="col-md-1 d-flex align-items-center pt-2">
             </div>
-
-              <div class="col-md-3 d-flex align-items-center pt-2">
-                <button type="submit" class="btn w-100 fw-bold bg-colorful-light"> <i class="fa-solid fa-filter"></i> Apply Filters</button>
+            <div class="small text-secondary">
+                {% if var_name_display == 'Instability Event' %}
+                    Select multiple values where needed, then click <span class="fw-semibold text-dark">Apply Filters</span>.
+                {% else %}
+                    Adjust the filters, then click <span class="fw-semibold text-dark">Apply Filters</span>.
+                {% endif %}
             </div>
         </div>
 
- 
-       
+        <div class="col-md-6 pb-2">
+            {% if var_name_display == 'Instability Event' %}
+                <label for="polity" class="text-secondary">Polities <small class="text-secondary">(matching: {{ polities|length }})</small></label>
+                <select name="polity" id="polity" class="form-select js-example-basic-multiple" multiple>
+                  {% for p in polities %}
+                    <option value="{{ p.id }}" {% if p.id|stringformat:"s" in selected_polity_ids %}selected{% endif %}>
+                        {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}] · {{ p.event_count }}
+                    </option>
+                  {% endfor %}
+                </select>
+            {% else %}
+                <label for="polity" class="text-secondary">Polity <small class="text-secondary">(total: {{ polities|length }})</small></label>
+                <select name="polity" id="polity" class="form-select js-example-basic-single">
+                  <option value="">All</option>
+                  {% for p in polities %}
+                    <option value="{{ p.id }}" {% if request.GET.polity == p.id|stringformat:"s" %}selected{% endif %}>
+                        {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}]
+                    </option>
+                  {% endfor %}
+                </select>
+            {% endif %}
+        </div>
 
-        <!-- <div class="col-auto">
-          <label>Before Created Date</label>
-          <input type="date" name="created_before" class="form-control" value="{{ request.GET.created_before }}">
-        </div> -->
-        <div class="col-auto align-self-end pb-0 mb-0">
-          {% if request.GET.year_from_min or request.GET.year_to_max or request.GET.created_before or request.GET.polity or request.GET.source or request.GET.selected_batch or request.GET.inst_type  or request.GET.ra_check or request.GET.inst_extent or request.GET.inst_intensity or request.GET.searched_name or request.GET.macro_event or request.GET.is_macro_event %}
+        {% if var_name_display == 'Instability Event' %}
+        <div class="col-md-6 pb-2">
+            <label for="macro_event" class="text-secondary">Umbrella Events</label>
+            <select name="macro_event" id="macro_event" class="form-select js-example-basic-multiple" multiple>
+              {% for event, count in macro_events_with_counts %}
+                <option value="{{ event }}" {% if event in selected_macro_events %}selected{% endif %}>
+                   {{ event }} · {{ count }}
+                </option>
+              {% endfor %}
+            </select>
+        </div>
 
-          <div class="py-1 px-0  d-inline-block" >
+        <div class="col-md-2 pb-2">
+            <label for="source" class="text-secondary">Source</label>
+            <select name="source" id="source" class="form-select js-example-basic-single">
+              <option value="">All</option>
+              <option value="llm" {% if selected_source == "llm" %}selected{% endif %}>LLM</option>
+              <option value="manual" {% if selected_source == "manual" %}selected{% endif %}>Manual</option>
+            </select>
+        </div>
+
+        <div class="col-md-2 pb-2">
+            <label for="row_quality" class="text-secondary">Row Quality</label>
+            <select name="row_quality" id="row_quality" class="form-select js-example-basic-single">
+              <option value="">All rows</option>
+              <option value="good" {% if selected_row_quality == "good" %}selected{% endif %}>Good rows only</option>
+            </select>
+        </div>
+
+        <div class="col-md-2 pb-2">
+            <label for="is_macro_event" class="text-secondary">Macroevent Record</label>
+            <select name="is_macro_event" id="is_macro_event" class="form-select js-example-basic-single">
+              <option value="">All</option>
+              <option value="true" {% if selected_is_macro_event == "true" %}selected{% endif %}>True</option>
+              <option value="false" {% if selected_is_macro_event == "false" %}selected{% endif %}>False</option>
+            </select>
+        </div>
+
+        {% if show_llm_batch_filter %}
+        <div class="col-md-2 pb-2">
+            <label for="selected_batch" class="text-secondary">LLM Batch</label>
+            <select name="selected_batch" id="selected_batch" class="form-select js-example-basic-single">
+              <option value="">All</option>
+              <option value="Batch 1" {% if selected_batch == "Batch 1" %}selected{% endif %}>Batch 1</option>
+              <option value="Batch 2" {% if selected_batch == "Batch 2" %}selected{% endif %}>Batch 2</option>
+              <option value="Batch 3" {% if selected_batch == "Batch 3" %}selected{% endif %}>Batch 3</option>
+              <option value="Batch 4" {% if selected_batch == "Batch 4" %}selected{% endif %}>Batch 4</option>
+            </select>
+        </div>
+        {% endif %}
+
+        <div class="col-md-4 pb-2">
+            <label for="inst_type_select" class="text-secondary d-block">Event Types</label>
+            <select id="inst_type_select" name="inst_type" class="form-select js-example-basic-multiple" multiple>
+              {% for type in instability_types %}
+                <option value="{{ type.id }}" {% if type.id|stringformat:"s" in selected_inst_type_ids %}selected{% endif %}>
+                  {{ type.name }} · {{ type.event_count }}
+                </option>
+              {% endfor %}
+            </select>
+        </div>
+
+        <div class="col-md-4 pb-2">
+            <label for="ra_check_select" class="text-secondary d-block">Researcher Checks</label>
+            <select id="ra_check_select" name="ra_check" class="form-select js-example-basic-multiple" multiple>
+              {% for check in check_choices %}
+                <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_ra_check_ids %}selected{% endif %}>
+                  {{ check.name }} · {{ check.event_count }}
+                </option>
+              {% endfor %}
+            </select>
+        </div>
+
+        <div class="col-md-4 pb-2">
+            <label for="inst_intensity_select" class="text-secondary">Intensity</label>
+            <select id="inst_intensity_select" name="inst_intensity" class="form-select js-example-basic-multiple" multiple>
+              {% for val, label, count in inst_intensity_filter_choices %}
+                <option value="{{ val }}" {% if val in selected_inst_intensity_values %}selected{% endif %}>
+                  {{ label }} · {{ count }}
+                </option>
+              {% endfor %}
+            </select>
+        </div>
+
+        <div class="col-md-4 pb-2">
+            <label for="inst_extent_select" class="text-secondary">Extent</label>
+            <select id="inst_extent_select" name="inst_extent" class="form-select js-example-basic-multiple" multiple>
+              {% for val, label, count in inst_extent_filter_choices %}
+                <option value="{{ val }}" {% if val in selected_inst_extent_values %}selected{% endif %}>
+                  {{ label }} · {{ count }}
+                </option>
+              {% endfor %}
+            </select>
+        </div>
+
+        <div class="col-md-4 pb-2">
+            <label for="searched_name" class="text-secondary">Event Name</label>
+            <input type="text" name="searched_name" id="searched_name" class="form-control" value="{{ name_query }}" placeholder="Search the coded event name">
+        </div>
+        {% endif %}
+
+        <div class="col-md-2 pb-2">
+            <label class="text-secondary" for="year_from_min">Start Year</label>
+            <input type="number" name="year_from_min" id="year_from_min" class="form-control" value="{{ request.GET.year_from_min }}">
+        </div>
+
+        <div class="col-md-2 pb-2">
+            <label class="text-secondary" for="year_to_max">End Year</label>
+            <input type="number" name="year_to_max" id="year_to_max" class="form-control" value="{{ request.GET.year_to_max }}">
+        </div>
+
+        <div class="col-md-4 d-flex align-items-end gap-2 pb-2 ms-auto">
+            <button type="submit" class="btn w-100 fw-bold bg-colorful-light">
+                <i class="fa-solid fa-filter"></i> Apply Filters
+            </button>
+            <a href="?" class="btn btn-outline-danger fw-semibold text-nowrap">Clear All</a>
+        </div>
+
+        {% if var_name_display == 'Instability Event' %}
+        <div class="col-12 small text-secondary pt-1">
+            <span class="fw-semibold text-dark">Good rows only</span> currently hides rows tagged as <span class="text-dark">Bad Row</span>, <span class="text-dark">Duplicate</span>, <span class="text-dark">Not Instability Event</span>, or <span class="text-dark">External Event</span>.
+        </div>
+        {% endif %}
+
+        <div class="col-12 align-self-end pb-0 mb-0">
+          {% if selected_polity_ids or request.GET.polity or selected_source or selected_batch or selected_inst_type_ids or selected_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or name_query or selected_macro_events or selected_is_macro_event or selected_row_quality or request.GET.year_from_min or request.GET.year_to_max %}
+
+          <div class="py-1 px-0 d-inline-block">
             <strong class="pb-2">Filters applied:</strong>
             <ul class="list-inline mb-1">
               {% if request.GET.year_from_min %}
-                <li class="list-inline-item px-2 mb-1 rounded  bg-orange-light text-dark">
-                    <span class="fw-light">Year ≥  </span>  <span class="fw-bold"> {{ request.GET.year_from_min }}</span>
-
+                <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
+                  <span class="fw-light">Year ≥ </span><span class="fw-bold">{{ request.GET.year_from_min }}</span>
                   <a href="?{% query_transform request year_from_min=None %}" class="text-dark ms-1" style="vertical-align:center;">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
                 </li>
               {% endif %}
-              {% if request.GET.year_to_max %}
-                <li class="list-inline-item px-2 mb-1 rounded  bg-orange-light text-dark">
-                    <span class="fw-light">Year ≤ </span>  <span class="fw-bold"> {{ request.GET.year_to_max }}</span>
 
+              {% if request.GET.year_to_max %}
+                <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
+                  <span class="fw-light">Year ≤ </span><span class="fw-bold">{{ request.GET.year_to_max }}</span>
                   <a href="?{% query_transform request year_to_max=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
                 </li>
               {% endif %}
-              {% for type in instability_types %}
-              {% if type.id|stringformat:"s" in selected_inst_type_ids %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
-                <small class="fw-light">Type:</small>  <span class="fw-bold"> {{ type.name }}</span>
-                  <a href="?{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endif %}
-            {% endfor %}
-            
-            {% if request.GET.inst_intensity %}
-            {% for val, label in INST_INTENSITY_CHOICES %}
-              {% if val == request.GET.inst_intensity %}
-                <li class="list-inline-item px-2 mb-1 rounded bg-danger-light text-dark">
-                    <small class="fw-light">Intensity:</small>  <span class="fw-bold"> {{ label }}</span>
-                  <a href="?{% query_transform request inst_intensity=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-                </li>
-              {% endif %}
-            {% endfor %}
-          {% endif %}
-          
-          {% if request.GET.inst_extent %}
-          {% for val, label in INST_EXTENT_CHOICES %}
-            {% if val == request.GET.inst_extent %}
-              <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
-                <small class="fw-light">Extent:</small>  <span class="fw-bold"> {{ label }}</span>
-                <a href="?{% query_transform request inst_extent=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-              </li>
-            {% endif %}
-          {% endfor %}
-        {% endif %}
 
-        {% if request.GET.searched_name %}
- 
-            <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
-              <small class="fw-light">Searched Name:</small>  <span class="fw-bold"> {{ request.GET.searched_name }}</span>
-              <a href="?{% query_transform request searched_name=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-            </li>
-
-      {% endif %}
-
-      {% if request.GET.macro_event %}
- 
-        <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
-            <small class="fw-light">Umbrella Event:</small>  <span class="fw-bold"> {{ request.GET.macro_event }}</span>
-            <a href="?{% query_transform request macro_event=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-        </li>
-
-    {% endif %}
-    {% if request.GET.is_macro_event %}
-        <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
-            <small class="fw-light">Macroevent:</small>  <span class="fw-bold">{{ request.GET.is_macro_event|title }}</span>
-            <a href="?{% query_transform request is_macro_event=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-        </li>
-    {% endif %}
-        
-        {% for check in check_choices %}
-        {% if check.id|stringformat:"s" in selected_ra_check_ids %}
-          <li class="list-inline-item px-2 mb-1 rounded bg-violet-light text-dark">
-            <small class="fw-light">RA Check:</small>  <span class="fw-bold"> {{ check.name }}</span>
-            <a href="?{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-          </li>
-        {% endif %}
-	      {% endfor %}
-
-	              <!-- {% if request.GET.created_before %}
-	                <li class="list-inline-item px-2 mb-1 rounded  bg-warning text-dark">
-	                  Created Before {{ request.GET.created_before }}
-	                  <a href="?{% query_transform request created_before=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
-	                </li>
-	              {% endif %} -->
-	              {% if selected_source %}
-	                <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
-	                  <small class="fw-light">Source:</small>
-	                  <span class="fw-bold">{{ selected_source|title }}</span>
-	                  <a href="?{% query_transform request source=None %}" class="text-dark ms-1" style="text-decoration: none;">
-	                    &nbsp;<i class="fa-solid fa-square-xmark"></i>
-	                  </a>
-	                </li>
-	              {% endif %}
-	              {% if selected_batch and show_llm_batch_filter %}
-	                <li class="list-inline-item px-2 mb-1 rounded  bg-warning-light text-dark">
-	                    <small class="fw-light">LLM Batch:</small> <span class="fw-bold">{{ selected_batch }}</span>
-	                    <a href="?{% query_transform request selected_batch=None %}" class="text-dark ms-1" style="text-decoration: none;">
-	                    &nbsp;<i class="fa-solid fa-square-xmark"></i>
-                    </a>
-                </li>
-            {% endif %}
-    
-              {% if request.GET.polity %}
-              {% with request.GET.polity as selected_polity_id %}
+              {% if var_name_display == 'Instability Event' %}
                 {% for p in polities %}
-                  {% if p.id|stringformat:"s" == selected_polity_id %}
-                  <li class="list-inline-item px-2 mb-1 rounded  bg-success-light text-dark">
-                    Polity: <b> {{ p.long_name }} </b>({{ p.new_name }})
-                      <a href="?{% query_transform request polity=None %}" class="text-dark text-decoration-none ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a></a>
-                  </li>
+                  {% if p.id|stringformat:"s" in selected_polity_ids %}
+                    <li class="list-inline-item px-2 mb-1 rounded bg-success-light text-dark">
+                      <small class="fw-light">Polity:</small> <span class="fw-bold">{{ p.long_name }}</span> ({{ p.new_name }})
+                      <a href="{% query_without request 'polity' p.id|stringformat:'s' %}" class="text-dark text-decoration-none ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                    </li>
                   {% endif %}
                 {% endfor %}
-              {% endwith %}
-            {% endif %}
+              {% elif request.GET.polity %}
+                {% with request.GET.polity as selected_polity_id %}
+                  {% for p in polities %}
+                    {% if p.id|stringformat:"s" == selected_polity_id %}
+                      <li class="list-inline-item px-2 mb-1 rounded bg-success-light text-dark">
+                        <small class="fw-light">Polity:</small> <span class="fw-bold">{{ p.long_name }}</span> ({{ p.new_name }})
+                        <a href="?{% query_transform request polity=None %}" class="text-dark text-decoration-none ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                      </li>
+                    {% endif %}
+                  {% endfor %}
+                {% endwith %}
+              {% endif %}
 
-            
+              {% for selected_macro_event in selected_macro_events %}
+                <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
+                  <small class="fw-light">Umbrella Event:</small> <span class="fw-bold">{{ selected_macro_event }}</span>
+                  <a href="{% query_without request 'macro_event' selected_macro_event %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                </li>
+              {% endfor %}
+
+              {% if selected_is_macro_event %}
+                <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
+                  <small class="fw-light">Macroevent:</small> <span class="fw-bold">{{ selected_is_macro_event|title }}</span>
+                  <a href="?{% query_transform request is_macro_event=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                </li>
+              {% endif %}
+
+              {% if selected_row_quality == "good" %}
+                <li class="list-inline-item px-2 mb-1 rounded bg-colorful text-dark">
+                  <small class="fw-light">Row Quality:</small> <span class="fw-bold">Good rows only</span>
+                  <a href="?{% query_transform request row_quality=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                </li>
+              {% endif %}
+
+              {% if name_query %}
+                <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
+                  <small class="fw-light">Event Name:</small> <span class="fw-bold">{{ name_query }}</span>
+                  <a href="?{% query_transform request searched_name=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                </li>
+              {% endif %}
+
+              {% for val, label in INST_INTENSITY_CHOICES %}
+                {% if val in selected_inst_intensity_values %}
+                  <li class="list-inline-item px-2 mb-1 rounded bg-danger-light text-dark">
+                    <small class="fw-light">Intensity:</small> <span class="fw-bold">{{ label }}</span>
+                    <a href="{% query_without request 'inst_intensity' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+
+              {% for val, label in INST_EXTENT_CHOICES %}
+                {% if val in selected_inst_extent_values %}
+                  <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
+                    <small class="fw-light">Extent:</small> <span class="fw-bold">{{ label }}</span>
+                    <a href="{% query_without request 'inst_extent' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+
+              {% for type in instability_types %}
+                {% if type.id|stringformat:"s" in selected_inst_type_ids %}
+                  <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
+                    <small class="fw-light">Type:</small> <span class="fw-bold">{{ type.name }}</span>
+                    <a href="{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+
+              {% for check in check_choices %}
+                {% if check.id|stringformat:"s" in selected_ra_check_ids %}
+                  <li class="list-inline-item px-2 mb-1 rounded bg-violet-light text-dark">
+                    <small class="fw-light">RA Check:</small> <span class="fw-bold">{{ check.name }}</span>
+                    <a href="{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+
+              {% if selected_source %}
+                <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
+                  <small class="fw-light">Source:</small> <span class="fw-bold">{{ selected_source|title }}</span>
+                  <a href="?{% query_transform request source=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                </li>
+              {% endif %}
+
+              {% if selected_batch and show_llm_batch_filter %}
+                <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
+                  <small class="fw-light">LLM Batch:</small> <span class="fw-bold">{{ selected_batch }}</span>
+                  <a href="?{% query_transform request selected_batch=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+                </li>
+              {% endif %}
             </ul>
-    
           </div>
-          <span>  <a href="?" class="btn btn-sm btn-outline-danger ms-2 px-2" style="padding-top:0px; padding-bottom:0px !important;">Clear All Filters</a></span>
-
           {% endif %}
         </div>
       </form>
@@ -923,12 +940,16 @@
 
 <script>
     $(document).ready(function() {
-        // Initialize Select2 with an empty dataset
-        $('.js-example-basic-single').select2();
+        $('.js-example-basic-single').select2({
+            width: '100%'
+        });
     });  
 
     $(document).ready(function() {
-        $('.js-example-basic-multiple').select2();
+        $('.js-example-basic-multiple').select2({
+            width: '100%',
+            closeOnSelect: false
+        });
     });
 
     var popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'));

--- a/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
+++ b/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
@@ -1,10 +1,10 @@
 {% load custom_filters %}
 
-{% if selected_polity_ids or selected_source_values or selected_batch_values or selected_inst_type_ids or selected_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or name_query or selected_macro_events or selected_is_macro_event or selected_row_quality or request.GET.year_from_min or request.GET.year_to_max %}
+{% if selected_polity_ids or selected_source_values or selected_batch_values or selected_event_ids or selected_text_queries or selected_inst_type_ids or selected_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or name_query or selected_macro_events or selected_is_macro_event or selected_row_quality or request.GET.year_from_min or request.GET.year_to_max %}
 <div class="w-100 pt-2 mb-0">
-  <div class="py-2 px-2 rounded" style="background: rgba(255, 255, 255, 0.58); border: 1px solid rgba(120, 40, 35, 0.1);">
-    <strong class="pb-2">Active filters:</strong>
-    <ul class="list-inline mb-1">
+  <div class="instability-active-filters">
+    <div class="instability-active-filter-label">Active filters</div>
+    <ul class="list-inline instability-active-filter-list mb-0">
       {% if request.GET.year_from_min %}
         <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
           <span class="fw-light">Year >= </span><span class="fw-bold">{{ request.GET.year_from_min }}</span>
@@ -44,8 +44,15 @@
 
       {% if selected_row_quality == "good" %}
         <li class="list-inline-item px-2 mb-1 rounded bg-colorful text-dark">
-          <small class="fw-light">Invalid rows:</small> <span class="fw-bold">Excluded</span>
-          <a href="?{% query_transform request row_quality=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <small class="fw-light">Invalid rows:</small>
+          <span class="fw-bold">
+            {% if selected_excluded_ra_check_labels %}
+              Excluding {{ selected_excluded_ra_check_labels|join:", " }}
+            {% else %}
+              No RA labels excluded
+            {% endif %}
+          </span>
+          <a href="?{% query_transform request row_quality=None excluded_ra_check=None excluded_ra_check_mode=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
@@ -55,6 +62,20 @@
           <a href="?{% query_transform request searched_name=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
+
+      {% for text_query in selected_text_queries %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
+          <small class="fw-light">Search:</small> <span class="fw-bold">{{ text_query }}</span>
+          <a href="{% query_without request 'q' text_query %}" class="text-dark ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endfor %}
+
+      {% for selected_event in selected_event_filters %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
+          <small class="fw-light">Event:</small> <span class="fw-bold">{{ selected_event.name }}</span>
+          <a href="{% query_without request 'event' selected_event.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endfor %}
 
       {% for val, label in INST_INTENSITY_CHOICES %}
         {% if val in selected_inst_intensity_values %}

--- a/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
+++ b/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
@@ -8,14 +8,14 @@
       {% if request.GET.year_from_min %}
         <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
           <span class="fw-light">Year >= </span><span class="fw-bold">{{ request.GET.year_from_min }}</span>
-          <a href="?{% query_transform request year_from_min=None %}" class="text-dark ms-1" style="vertical-align:center;">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="?{% query_transform request year_from_min=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
       {% if request.GET.year_to_max %}
         <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
           <span class="fw-light">Year <= </span><span class="fw-bold">{{ request.GET.year_to_max }}</span>
-          <a href="?{% query_transform request year_to_max=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="?{% query_transform request year_to_max=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
@@ -23,7 +23,7 @@
         {% if p.id|stringformat:"s" in selected_polity_ids %}
           <li class="list-inline-item px-2 mb-1 rounded bg-success-light text-dark">
             <small class="fw-light">Polity:</small> <span class="fw-bold">{{ p.long_name }}</span> ({{ p.new_name }})
-            <a href="{% query_without request 'polity' p.id|stringformat:'s' %}" class="text-dark text-decoration-none ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+            <a href="{% query_without request 'polity' p.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
           </li>
         {% endif %}
       {% endfor %}
@@ -31,14 +31,21 @@
       {% for selected_macro_event in selected_macro_events %}
         <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
           <small class="fw-light">Umbrella Event:</small> <span class="fw-bold">{{ selected_macro_event }}</span>
-          <a href="{% query_without request 'macro_event' selected_macro_event %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="{% query_without request 'macro_event' selected_macro_event %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endfor %}
 
       {% if selected_is_macro_event %}
         <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
-          <small class="fw-light">Macroevent:</small> <span class="fw-bold">{{ selected_is_macro_event|title }}</span>
-          <a href="?{% query_transform request is_macro_event=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <small class="fw-light">Macroevent:</small>
+          <span class="fw-bold">
+            {% if selected_is_macro_event == "true" %}
+              Macro events only
+            {% else %}
+              Normal events only
+            {% endif %}
+          </span>
+          <a href="?{% query_transform request is_macro_event=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
@@ -52,28 +59,28 @@
               No RA labels excluded
             {% endif %}
           </span>
-          <a href="?{% query_transform request row_quality=None excluded_ra_check=None excluded_ra_check_mode=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="?{% query_transform request row_quality=None excluded_ra_check=None excluded_ra_check_mode=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
       {% if name_query %}
         <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
           <small class="fw-light">Event Name:</small> <span class="fw-bold">{{ name_query }}</span>
-          <a href="?{% query_transform request searched_name=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="?{% query_transform request searched_name=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
       {% for text_query in selected_text_queries %}
         <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
           <small class="fw-light">Search:</small> <span class="fw-bold">{{ text_query }}</span>
-          <a href="{% query_without request 'q' text_query %}" class="text-dark ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="{% query_without request 'q' text_query %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endfor %}
 
       {% for selected_event in selected_event_filters %}
         <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
           <small class="fw-light">Event:</small> <span class="fw-bold">{{ selected_event.name }}</span>
-          <a href="{% query_without request 'event' selected_event.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="{% query_without request 'event' selected_event.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endfor %}
 
@@ -81,7 +88,7 @@
         {% if val in selected_inst_intensity_values %}
           <li class="list-inline-item px-2 mb-1 rounded bg-danger-light text-dark">
             <small class="fw-light">Intensity:</small> <span class="fw-bold">{{ label }}</span>
-            <a href="{% query_without request 'inst_intensity' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+            <a href="{% query_without request 'inst_intensity' val %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
           </li>
         {% endif %}
       {% endfor %}
@@ -90,7 +97,7 @@
         {% if val in selected_inst_extent_values %}
           <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
             <small class="fw-light">Extent:</small> <span class="fw-bold">{{ label }}</span>
-            <a href="{% query_without request 'inst_extent' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+            <a href="{% query_without request 'inst_extent' val %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
           </li>
         {% endif %}
       {% endfor %}
@@ -99,7 +106,7 @@
         {% if type.id|stringformat:"s" in selected_inst_type_ids %}
           <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
             <small class="fw-light">Type:</small> <span class="fw-bold">{{ type.name }}</span>
-            <a href="{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+            <a href="{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
           </li>
         {% endif %}
       {% endfor %}
@@ -108,7 +115,7 @@
         {% if check.id|stringformat:"s" in selected_ra_check_ids %}
           <li class="list-inline-item px-2 mb-1 rounded bg-violet-light text-dark">
             <small class="fw-light">RA Check:</small> <span class="fw-bold">{{ check.name }}</span>
-            <a href="{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+            <a href="{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
           </li>
         {% endif %}
       {% endfor %}
@@ -116,14 +123,14 @@
       {% if batch_filter_forces_llm %}
         <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
           <small class="fw-light">Source:</small> <span class="fw-bold">LLM only</span> <small>(batch filter)</small>
-          <a href="?{% query_transform request selected_batch=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="?{% query_transform request selected_batch=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% else %}
         {% for source_value, source_label, source_count in source_filter_choices %}
           {% if source_value in selected_source_values %}
             <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
               <small class="fw-light">Source:</small> <span class="fw-bold">{{ source_label }}</span>
-              <a href="{% query_without request 'source' source_value %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+              <a href="{% query_without request 'source' source_value %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
             </li>
           {% endif %}
         {% endfor %}
@@ -132,7 +139,7 @@
       {% for selected_batch in selected_batch_values %}
         <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
           <small class="fw-light">LLM Batch:</small> <span class="fw-bold">{{ selected_batch }}</span>
-          <a href="{% query_without request 'selected_batch' selected_batch %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          <a href="{% query_without request 'selected_batch' selected_batch %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endfor %}
     </ul>

--- a/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
+++ b/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
@@ -1,0 +1,120 @@
+{% load custom_filters %}
+
+{% if selected_polity_ids or selected_source_values or selected_batch_values or selected_inst_type_ids or selected_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or name_query or selected_macro_events or selected_is_macro_event or selected_row_quality or request.GET.year_from_min or request.GET.year_to_max %}
+<div class="w-100 pt-2 mb-0">
+  <div class="py-2 px-2 rounded" style="background: rgba(255, 255, 255, 0.58); border: 1px solid rgba(120, 40, 35, 0.1);">
+    <strong class="pb-2">Active filters:</strong>
+    <ul class="list-inline mb-1">
+      {% if request.GET.year_from_min %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
+          <span class="fw-light">Year >= </span><span class="fw-bold">{{ request.GET.year_from_min }}</span>
+          <a href="?{% query_transform request year_from_min=None %}" class="text-dark ms-1" style="vertical-align:center;">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endif %}
+
+      {% if request.GET.year_to_max %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
+          <span class="fw-light">Year <= </span><span class="fw-bold">{{ request.GET.year_to_max }}</span>
+          <a href="?{% query_transform request year_to_max=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endif %}
+
+      {% for p in polities %}
+        {% if p.id|stringformat:"s" in selected_polity_ids %}
+          <li class="list-inline-item px-2 mb-1 rounded bg-success-light text-dark">
+            <small class="fw-light">Polity:</small> <span class="fw-bold">{{ p.long_name }}</span> ({{ p.new_name }})
+            <a href="{% query_without request 'polity' p.id|stringformat:'s' %}" class="text-dark text-decoration-none ms-1">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          </li>
+        {% endif %}
+      {% endfor %}
+
+      {% for selected_macro_event in selected_macro_events %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
+          <small class="fw-light">Umbrella Event:</small> <span class="fw-bold">{{ selected_macro_event }}</span>
+          <a href="{% query_without request 'macro_event' selected_macro_event %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endfor %}
+
+      {% if selected_is_macro_event %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
+          <small class="fw-light">Macroevent:</small> <span class="fw-bold">{{ selected_is_macro_event|title }}</span>
+          <a href="?{% query_transform request is_macro_event=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endif %}
+
+      {% if selected_row_quality == "good" %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-colorful text-dark">
+          <small class="fw-light">Invalid rows:</small> <span class="fw-bold">Excluded</span>
+          <a href="?{% query_transform request row_quality=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endif %}
+
+      {% if name_query %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-uncoded-light text-dark">
+          <small class="fw-light">Event Name:</small> <span class="fw-bold">{{ name_query }}</span>
+          <a href="?{% query_transform request searched_name=None %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endif %}
+
+      {% for val, label in INST_INTENSITY_CHOICES %}
+        {% if val in selected_inst_intensity_values %}
+          <li class="list-inline-item px-2 mb-1 rounded bg-danger-light text-dark">
+            <small class="fw-light">Intensity:</small> <span class="fw-bold">{{ label }}</span>
+            <a href="{% query_without request 'inst_intensity' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          </li>
+        {% endif %}
+      {% endfor %}
+
+      {% for val, label in INST_EXTENT_CHOICES %}
+        {% if val in selected_inst_extent_values %}
+          <li class="list-inline-item px-2 mb-1 rounded bg-secondary-light text-dark">
+            <small class="fw-light">Extent:</small> <span class="fw-bold">{{ label }}</span>
+            <a href="{% query_without request 'inst_extent' val %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          </li>
+        {% endif %}
+      {% endfor %}
+
+      {% for type in instability_types %}
+        {% if type.id|stringformat:"s" in selected_inst_type_ids %}
+          <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
+            <small class="fw-light">Type:</small> <span class="fw-bold">{{ type.name }}</span>
+            <a href="{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          </li>
+        {% endif %}
+      {% endfor %}
+
+      {% for check in check_choices %}
+        {% if check.id|stringformat:"s" in selected_ra_check_ids %}
+          <li class="list-inline-item px-2 mb-1 rounded bg-violet-light text-dark">
+            <small class="fw-light">RA Check:</small> <span class="fw-bold">{{ check.name }}</span>
+            <a href="{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1">&nbsp;&nbsp;&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+          </li>
+        {% endif %}
+      {% endfor %}
+
+      {% if batch_filter_forces_llm %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
+          <small class="fw-light">Source:</small> <span class="fw-bold">LLM only</span> <small>(batch filter)</small>
+          <a href="?{% query_transform request selected_batch=None %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% else %}
+        {% for source_value, source_label, source_count in source_filter_choices %}
+          {% if source_value in selected_source_values %}
+            <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
+              <small class="fw-light">Source:</small> <span class="fw-bold">{{ source_label }}</span>
+              <a href="{% query_without request 'source' source_value %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+
+      {% for selected_batch in selected_batch_values %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-warning-light text-dark">
+          <small class="fw-light">LLM Batch:</small> <span class="fw-bold">{{ selected_batch }}</span>
+          <a href="{% query_without request 'selected_batch' selected_batch %}" class="text-dark ms-1" style="text-decoration: none;">&nbsp;<i class="fa-solid fa-square-xmark"></i></a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endif %}

--- a/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
+++ b/seshat/apps/core/templates/core/partials/_instability_active_filter_chips.html
@@ -1,31 +1,29 @@
 {% load custom_filters %}
 
-{% if selected_polity_ids or selected_source_values or selected_batch_values or selected_event_ids or selected_text_queries or selected_inst_type_ids or selected_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or name_query or selected_macro_events or selected_is_macro_event or selected_row_quality or request.GET.year_from_min or request.GET.year_to_max %}
+{% if selected_polity_ids or selected_source_values or selected_batch_values or selected_event_ids or selected_text_queries or selected_inst_type_ids or selected_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or name_query or selected_macro_events or selected_is_macro_event or selected_row_quality or selected_year_from_min is not None or selected_year_to_max is not None %}
 <div class="w-100 pt-2 mb-0">
   <div class="instability-active-filters">
     <div class="instability-active-filter-label">Active filters</div>
     <ul class="list-inline instability-active-filter-list mb-0">
-      {% if request.GET.year_from_min %}
+      {% if selected_year_from_min is not None %}
         <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
-          <span class="fw-light">Year >= </span><span class="fw-bold">{{ request.GET.year_from_min }}</span>
+          <span class="fw-light">Year >= </span><span class="fw-bold">{{ selected_year_from_min }}</span>
           <a href="?{% query_transform request year_from_min=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
-      {% if request.GET.year_to_max %}
+      {% if selected_year_to_max is not None %}
         <li class="list-inline-item px-2 mb-1 rounded bg-orange-light text-dark">
-          <span class="fw-light">Year <= </span><span class="fw-bold">{{ request.GET.year_to_max }}</span>
+          <span class="fw-light">Year <= </span><span class="fw-bold">{{ selected_year_to_max }}</span>
           <a href="?{% query_transform request year_to_max=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
         </li>
       {% endif %}
 
-      {% for p in polities %}
-        {% if p.id|stringformat:"s" in selected_polity_ids %}
-          <li class="list-inline-item px-2 mb-1 rounded bg-success-light text-dark">
-            <small class="fw-light">Polity:</small> <span class="fw-bold">{{ p.long_name }}</span> ({{ p.new_name }})
-            <a href="{% query_without request 'polity' p.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
-          </li>
-        {% endif %}
+      {% for p in selected_polity_filters %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-success-light text-dark">
+          <small class="fw-light">Polity:</small> <span class="fw-bold">{{ p.long_name }}</span> ({{ p.new_name }})
+          <a href="{% query_without request 'polity' p.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
+        </li>
       {% endfor %}
 
       {% for selected_macro_event in selected_macro_events %}
@@ -51,12 +49,12 @@
 
       {% if selected_row_quality == "good" %}
         <li class="list-inline-item px-2 mb-1 rounded bg-colorful text-dark">
-          <small class="fw-light">Invalid rows:</small>
+          <small class="fw-light">Researcher checks excluded:</small>
           <span class="fw-bold">
             {% if selected_excluded_ra_check_labels %}
-              Excluding {{ selected_excluded_ra_check_labels|join:", " }}
+              {{ selected_excluded_ra_check_labels|join:", " }}
             {% else %}
-              No RA labels excluded
+              None
             {% endif %}
           </span>
           <a href="?{% query_transform request row_quality=None excluded_ra_check=None excluded_ra_check_mode=None %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
@@ -102,22 +100,18 @@
         {% endif %}
       {% endfor %}
 
-      {% for type in instability_types %}
-        {% if type.id|stringformat:"s" in selected_inst_type_ids %}
-          <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
-            <small class="fw-light">Type:</small> <span class="fw-bold">{{ type.name }}</span>
-            <a href="{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
-          </li>
-        {% endif %}
+      {% for type in selected_inst_type_filters %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-info-light text-dark">
+          <small class="fw-light">Type:</small> <span class="fw-bold">{{ type.name }}</span>
+          <a href="{% query_without request 'inst_type' type.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
+        </li>
       {% endfor %}
 
-      {% for check in check_choices %}
-        {% if check.id|stringformat:"s" in selected_ra_check_ids %}
-          <li class="list-inline-item px-2 mb-1 rounded bg-violet-light text-dark">
-            <small class="fw-light">RA Check:</small> <span class="fw-bold">{{ check.name }}</span>
-            <a href="{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
-          </li>
-        {% endif %}
+      {% for check in selected_ra_check_filters %}
+        <li class="list-inline-item px-2 mb-1 rounded bg-violet-light text-dark">
+          <small class="fw-light">RA Check:</small> <span class="fw-bold">{{ check.name }}</span>
+          <a href="{% query_without request 'ra_check' check.id|stringformat:'s' %}" class="text-dark ms-1"><i class="fa-solid fa-square-xmark"></i></a>
+        </li>
       {% endfor %}
 
       {% if batch_filter_forces_llm %}

--- a/seshat/apps/core/templates/core/partials/_instability_list_filters.html
+++ b/seshat/apps/core/templates/core/partials/_instability_list_filters.html
@@ -52,10 +52,15 @@
   }
 
   .instability-summary-main {
-    display: grid;
-    grid-template-columns: minmax(18rem, 1fr) auto;
+    min-width: 0;
+  }
+
+  .instability-summary-header {
+    align-items: center;
+    display: flex;
     gap: 0.85rem;
-    align-items: end;
+    justify-content: space-between;
+    margin-bottom: 0.45rem;
   }
 
   .instability-global-filter {
@@ -63,7 +68,8 @@
   }
 
   .instability-global-filter label,
-  .instability-quick-row-label {
+  .instability-quick-row-label,
+  .instability-year-range-label {
     display: block;
     color: var(--instability-muted);
     font-size: 0.72rem;
@@ -85,6 +91,12 @@
     border-radius: 999px;
   }
 
+  .instability-summary-actions .btn {
+    font-size: 0.82rem;
+    min-height: 2.35rem;
+    padding: 0.4rem 0.8rem;
+  }
+
   .instability-summary-actions .btn[type="submit"] {
     border: 1px solid rgba(15, 118, 110, 0.3);
     box-shadow: 0 8px 18px rgba(15, 118, 110, 0.12);
@@ -93,12 +105,54 @@
 
   .instability-quick-row {
     align-items: center;
-    border-top: 1px dashed var(--instability-line);
     display: flex;
     flex-wrap: wrap;
     gap: 0.45rem;
+    min-width: 0;
+  }
+
+  .instability-summary-tools {
+    align-items: flex-end;
+    border-top: 1px dashed var(--instability-line);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    justify-content: space-between;
     margin-top: 0.8rem;
     padding-top: 0.75rem;
+  }
+
+  .instability-year-range {
+    align-items: flex-end;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-left: auto;
+  }
+
+  .instability-year-range-label {
+    margin: 0 0.2rem 0.38rem 0;
+  }
+
+  .instability-year-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.18rem;
+  }
+
+  .instability-year-field label {
+    color: var(--instability-muted);
+    font-size: 0.68rem;
+    font-weight: 700;
+    line-height: 1;
+    margin: 0;
+  }
+
+  .instability-year-field .form-control {
+    border-radius: 10px;
+    min-height: 2.35rem;
+    padding: 0.3rem 0.55rem;
+    width: 7rem;
   }
 
   .instability-active-filters {
@@ -313,21 +367,6 @@
     margin-top: 0.25rem;
   }
 
-  .instability-filter-actions {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    margin-top: 0.45rem;
-  }
-
-  .instability-filter-actions .btn {
-    border-radius: 999px;
-    font-size: 0.72rem;
-    font-weight: 700;
-    padding: 0.22rem 0.55rem;
-  }
-
   .instability-filter-panel .form-control {
     min-height: 42px;
     border: 1px solid rgba(120, 40, 35, 0.16);
@@ -348,6 +387,9 @@
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple {
+    align-items: stretch;
+    display: flex;
+    flex-direction: column;
     min-height: 42px;
     max-height: 118px;
     overflow-y: auto;
@@ -358,15 +400,11 @@
   }
 
   .instability-filter-field .select2-container--default .select2-selection--multiple {
-    align-items: center;
-    display: flex;
     min-height: 42px;
-    max-height: 96px;
+    max-height: 148px;
   }
 
   .instability-global-filter .select2-container--default .select2-selection--multiple {
-    align-items: center;
-    display: flex;
     min-height: 58px;
     max-height: 140px;
     padding: 8px 10px;
@@ -381,23 +419,35 @@
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__rendered {
+    align-content: flex-start;
     display: flex;
+    flex: 0 0 auto;
     flex-wrap: wrap;
     gap: 4px;
+    margin: 0;
     min-width: 0;
     padding: 0;
+    width: 100%;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__rendered:empty {
+    display: none;
   }
 
   .instability-filter-field .select2-container--default .select2-selection--multiple .select2-selection__rendered {
-    align-items: center;
+    align-items: flex-start;
     min-height: 2rem;
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__choice {
     position: relative;
-    display: inline-block;
+    align-items: center;
+    display: inline-flex;
+    flex: 0 0 auto;
+    line-height: 1.2;
     max-width: 100%;
     margin: 0;
+    min-height: 2rem;
     padding: 0.28rem 1.75rem 0.28rem 0.62rem;
     border-color: rgba(15, 118, 110, 0.26);
     border-radius: 999px;
@@ -439,9 +489,21 @@
   }
 
   .instability-filter-panel .select2-container--default .select2-search--inline .select2-search__field {
-    min-width: 16rem;
+    box-sizing: border-box;
+    display: block;
     margin-top: 3px;
+    min-width: 0;
+    text-align: left;
+    width: 100% !important;
     color: var(--instability-ink);
+  }
+
+  .instability-filter-panel .select2-container--default .select2-search--inline {
+    display: block;
+    float: none;
+    flex: 0 0 auto;
+    min-width: 0;
+    width: 100%;
   }
 
   .instability-filter-field .select2-container--default .select2-search--inline .select2-search__field {
@@ -600,16 +662,44 @@
   }
 
   @media (max-width: 991px) {
-    .instability-summary-main {
-      grid-template-columns: 1fr;
-    }
-
     .instability-summary-actions {
       justify-content: flex-start;
     }
   }
 
   @media (max-width: 767px) {
+    .instability-filter-summary {
+      position: static;
+    }
+
+    .instability-summary-header {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.45rem;
+    }
+
+    .instability-summary-actions {
+      width: 100%;
+    }
+
+    .instability-summary-tools {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .instability-year-range {
+      margin-left: 0;
+      width: 100%;
+    }
+
+    .instability-year-field {
+      flex: 1 1 7rem;
+    }
+
+    .instability-year-field .form-control {
+      width: 100%;
+    }
+
     .instability-choice-toggle {
       grid-template-columns: 1fr;
     }
@@ -645,7 +735,15 @@
             <div class="instability-filter-summary">
                 <div class="instability-summary-main">
                     <div class="instability-global-filter">
-                        <label for="global_filter_tokens" class="small fw-semibold text-secondary mb-1">Search & add filters</label>
+                        <div class="instability-summary-header">
+                            <label for="global_filter_tokens" class="small fw-semibold text-secondary mb-0">Search & add filters</label>
+                            <div class="d-flex flex-wrap align-items-center gap-2 instability-summary-actions">
+                                <button type="submit" class="btn fw-bold bg-colorful-light">
+                                    <i class="fa-solid fa-filter"></i> Apply filters
+                                </button>
+                                <a href="?" class="btn btn-outline-danger fw-semibold text-nowrap">Clear all</a>
+                            </div>
+                        </div>
                         <select id="global_filter_tokens" class="form-select js-instability-token-filter" multiple data-ajax-url="{% url 'instability_event-filter-tokens' %}" data-placeholder="Search events, polities, batches, sources, types, checks, macro events, or normal events">
                           {% for token in selected_global_filter_tokens %}
                             <option value="{{ token.token_id }}" selected>{{ token.label }}</option>
@@ -653,41 +751,48 @@
                         </select>
                         <div class="instability-filter-help mb-0">Type to preview matching filter tokens. Selected tokens become normal filters when you apply.</div>
                     </div>
-
-                    <div class="d-flex flex-wrap align-items-center gap-2 instability-summary-actions">
-                        <button type="submit" class="btn btn-sm fw-bold bg-colorful-light">
-                            <i class="fa-solid fa-filter"></i> Apply
-                        </button>
-                        <a href="?" class="btn btn-outline-danger btn-sm fw-semibold text-nowrap">Clear All</a>
-                    </div>
                 </div>
 
-                <div class="instability-quick-row">
-                    <span class="instability-quick-row-label mb-0 me-1">Common views</span>
-                    <a href="?{% query_transform request row_quality='good' excluded_ra_check=None excluded_ra_check_mode=None %}" class="btn btn-sm {% if selected_row_quality == 'good' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
-                        Exclude invalid rows
-                    </a>
-                    {% if selected_row_quality == 'good' %}
-                        <a href="?{% query_transform request row_quality=None excluded_ra_check=None excluded_ra_check_mode=None %}" class="btn btn-sm btn-outline-secondary">Include invalid rows</a>
-                    {% endif %}
-                    <a href="?{% query_transform request source='llm' %}" class="btn btn-sm {% if explicit_selected_source == 'llm' and not batch_filter_forces_llm %}btn-dark{% else %}btn-outline-secondary{% endif %}">
-                        Only LLM
-                    </a>
-                    {% if batch_filter_forces_llm %}
-                        <span class="btn btn-sm btn-outline-secondary disabled" aria-disabled="true" title="Batch filters are LLM-only. Clear batches before selecting manual rows." data-instability-source-conflict="batch">
-                            Only manual
-                        </span>
-                    {% else %}
-                        <a href="?{% query_transform request source='manual' selected_batch=None %}" class="btn btn-sm {% if explicit_selected_source == 'manual' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
-                            Only manual
-                        </a>
-                    {% endif %}
-                    {% if explicit_selected_source_values and not batch_filter_forces_llm %}
-                        <a href="?{% query_transform request source=None %}" class="btn btn-sm btn-outline-secondary" data-instability-clear-sources="true">All sources</a>
-                    {% endif %}
-                    {% if selected_batch_values %}
-                        <a href="?{% query_transform request selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All batches</a>
-                    {% endif %}
+                <div class="instability-summary-tools">
+                    <div class="instability-quick-row">
+                        <span class="instability-quick-row-label mb-0 me-1">Common views</span>
+                        <button type="button" class="btn btn-sm {% if default_invalid_filter_active %}btn-dark{% else %}btn-outline-secondary{% endif %}" data-instability-quick-action="exclude-invalid">
+                            Exclude invalid rows
+                        </button>
+                        {% if selected_row_quality == 'good' %}
+                            <button type="button" class="btn btn-sm btn-outline-secondary" data-instability-quick-action="include-invalid">Include invalid rows</button>
+                        {% endif %}
+                        <button type="button" class="btn btn-sm {% if explicit_selected_source == 'llm' and not batch_filter_forces_llm %}btn-dark{% else %}btn-outline-secondary{% endif %}" data-instability-quick-action="only-llm">
+                            Only LLM
+                        </button>
+                        {% if batch_filter_forces_llm %}
+                            <span class="btn btn-sm btn-outline-secondary disabled" aria-disabled="true" title="Batch filters are LLM-only. Clear batches before selecting manual rows." data-instability-source-conflict="batch">
+                                Only manual
+                            </span>
+                        {% else %}
+                            <button type="button" class="btn btn-sm {% if explicit_selected_source == 'manual' %}btn-dark{% else %}btn-outline-secondary{% endif %}" data-instability-quick-action="only-manual">
+                                Only manual
+                            </button>
+                        {% endif %}
+                        {% if explicit_selected_source_values and not batch_filter_forces_llm %}
+                            <button type="button" class="btn btn-sm btn-outline-secondary" data-instability-quick-action="all-sources" data-instability-clear-sources="true">All sources</button>
+                        {% endif %}
+                        {% if selected_batch_values %}
+                            <button type="button" class="btn btn-sm btn-outline-secondary" data-instability-quick-action="all-batches">All batches</button>
+                        {% endif %}
+                    </div>
+
+                    <div class="instability-year-range" role="group" aria-label="Year range">
+                        <span class="instability-year-range-label">Year range</span>
+                        <div class="instability-year-field">
+                            <label for="year_from_min">From</label>
+                            <input type="number" name="year_from_min" id="year_from_min" class="form-control" value="{{ selected_year_from_min|default_if_none:'' }}" placeholder="Min">
+                        </div>
+                        <div class="instability-year-field">
+                            <label for="year_to_max">To</label>
+                            <input type="number" name="year_to_max" id="year_to_max" class="form-control" value="{{ selected_year_to_max|default_if_none:'' }}" placeholder="Max">
+                        </div>
+                    </div>
                 </div>
 
                 {% include "core/partials/_instability_active_filter_chips.html" %}
@@ -780,7 +885,7 @@
                                     <label for="source" class="text-secondary">Sources</label>
                                     <select name="source" id="source" class="form-select js-instability-multiple" multiple data-placeholder="All sources">
                                       {% for value, label, count in source_filter_choices %}
-                                        <option value="{{ value }}" {% if value in selected_source_values %}selected{% endif %}>{{ label }} - {{ count }}</option>
+                                        <option value="{{ value }}" {% if value in explicit_selected_source_values %}selected{% endif %}>{{ label }} - {{ count }}</option>
                                       {% endfor %}
                                     </select>
                                     <div class="instability-filter-help">Select LLM, manual, or both.</div>
@@ -820,10 +925,10 @@
                                 <span>All types</span>
                             {% endif %}
                             {% if selected_ra_check_ids %}
-                                <span class="badge rounded-pill bg-violet-light text-dark">{{ selected_ra_check_ids|length }} required checks</span>
+                                <span class="badge rounded-pill bg-violet-light text-dark">{{ selected_ra_check_ids|length }} checks included</span>
                             {% endif %}
                             {% if selected_row_quality %}
-                                <span class="badge rounded-pill bg-colorful text-dark">Invalid rows excluded</span>
+                                <span class="badge rounded-pill bg-colorful text-dark">{{ selected_excluded_ra_check_ids|length }} checks excluded</span>
                             {% endif %}
                             {% if selected_inst_intensity_values or selected_inst_extent_values %}
                                 <span class="badge rounded-pill bg-secondary-light text-dark">Severity filters active</span>
@@ -847,7 +952,7 @@
                                 </div>
 
                                 <div class="col-md-4 pb-2 instability-filter-field">
-                                    <label for="ra_check_select" class="text-secondary d-block">Require Researcher Checks</label>
+                                    <label for="ra_check_select" class="text-secondary d-block">Include by Researcher Check</label>
                                     <select id="ra_check_select" name="ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Search researcher checks">
                                       {% for check in check_choices %}
                                         <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_ra_check_ids %}selected{% endif %}>
@@ -855,24 +960,19 @@
                                         </option>
                                       {% endfor %}
                                     </select>
-                                    <div class="instability-filter-help">Keep only rows that carry at least one selected review label.</div>
+                                    <div class="instability-filter-help">Show rows carrying at least one selected researcher check.</div>
                                 </div>
 
                                 <div class="col-md-4 pb-2 instability-filter-field">
-                                    <label for="excluded_ra_check_select" class="text-secondary d-block">Exclude Researcher Checks</label>
-                                    <select id="excluded_ra_check_select" name="excluded_ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Default invalid labels" data-default-values="{{ default_excluded_ra_check_ids|join:',' }}">
+                                    <label for="excluded_ra_check_select" class="text-secondary d-block">Exclude by Researcher Check</label>
+                                    <select id="excluded_ra_check_select" name="excluded_ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Search researcher checks" data-default-values="{{ default_excluded_ra_check_ids|join:',' }}">
                                       {% for check in excluded_ra_check_choices %}
                                         <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_excluded_ra_check_ids %}selected{% endif %}>
                                           {{ check.name }} - {{ check.event_count }}
                                         </option>
                                       {% endfor %}
                                     </select>
-                                    <div class="instability-filter-actions">
-                                        <button type="button" class="btn btn-outline-secondary" data-instability-excluded-action="default">Default invalid</button>
-                                        <button type="button" class="btn btn-outline-secondary" data-instability-excluded-action="all">Exclude all labels</button>
-                                        <button type="button" class="btn btn-outline-secondary" data-instability-excluded-action="clear">Exclude none</button>
-                                    </div>
-                                    <div class="instability-filter-help">This removes rows with selected labels. Exclude none clears this rule and includes labels again.</div>
+                                    <div class="instability-filter-help">Hide rows carrying at least one selected researcher check. Use Exclude invalid rows for the default invalid set.</div>
                                 </div>
 
                                 <div class="col-md-4 pb-2 instability-filter-field">
@@ -901,41 +1001,6 @@
                     </div>
                 </section>
 
-                <section class="instability-filter-card">
-                    <button class="instability-filter-card-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#instability-time-section" aria-controls="instability-time-section" aria-expanded="{% if request.GET.year_from_min or request.GET.year_to_max %}true{% else %}false{% endif %}">
-                        <span class="instability-filter-card-title">
-                            <span class="small fw-bold text-dark">Time</span>
-                            <span class="small text-secondary">Constrain the effective year range.</span>
-                        </span>
-                        <span class="instability-filter-card-summary">
-                            {% if request.GET.year_from_min %}
-                                <span class="badge rounded-pill bg-orange-light text-dark">From {{ request.GET.year_from_min }}</span>
-                            {% endif %}
-                            {% if request.GET.year_to_max %}
-                                <span class="badge rounded-pill bg-orange-light text-dark">To {{ request.GET.year_to_max }}</span>
-                            {% endif %}
-                            {% if not request.GET.year_from_min and not request.GET.year_to_max %}
-                                <span>All years</span>
-                            {% endif %}
-                        </span>
-                        <i class="fa-solid fa-chevron-down instability-filter-card-chevron"></i>
-                    </button>
-                    <div id="instability-time-section" class="collapse {% if request.GET.year_from_min or request.GET.year_to_max %}show{% endif %}">
-                        <div class="instability-filter-card-body">
-                            <div class="row g-2">
-                                <div class="col-md-2 pb-2 instability-filter-field">
-                                    <label class="text-secondary" for="year_from_min">Start Year</label>
-                                    <input type="number" name="year_from_min" id="year_from_min" class="form-control" value="{{ request.GET.year_from_min }}" placeholder="Min">
-                                </div>
-
-                                <div class="col-md-2 pb-2 instability-filter-field">
-                                    <label class="text-secondary" for="year_to_max">End Year</label>
-                                    <input type="number" name="year_to_max" id="year_to_max" class="form-control" value="{{ request.GET.year_to_max }}" placeholder="Max">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </section>
             </div>
         </div>
       </form>
@@ -950,6 +1015,7 @@
     const $instabilitySelects = jQuery(".js-instability-multiple");
     const $tokenFilter = jQuery(".js-instability-token-filter");
     const $filterPanel = jQuery(".instability-filter-panel");
+    const $filterForm = $filterPanel.find("form");
     const $rowQuality = jQuery("#row_quality");
     const $raCheckSelect = jQuery("#ra_check_select");
     const $excludedRaCheckSelect = jQuery("#excluded_ra_check_select");
@@ -1005,14 +1071,6 @@
     function getDefaultExcludedRaCheckIds() {
       const defaultValues = String($excludedRaCheckSelect.data("default-values") || "");
       return defaultValues.split(",").filter(function (value) {
-        return value;
-      });
-    }
-
-    function getAllExcludedRaCheckIds() {
-      return $excludedRaCheckSelect.find("option").map(function () {
-        return this.value;
-      }).get().filter(function (value) {
         return value;
       });
     }
@@ -1085,6 +1143,41 @@
 
       $tokenFilter.val(nextTokens).trigger("change");
       return true;
+    }
+
+    function removeAllTokenValuesByKind(kind) {
+      return removeTokenValuesByKind(kind, getTokenValuesByKind(kind));
+    }
+
+    function setSourceFilter(values) {
+      jQuery("#source").val(values).trigger("change");
+      removeAllTokenValuesByKind("source");
+    }
+
+    function removeTokenFromBackedField(token) {
+      if (!token) {
+        return;
+      }
+
+      const fieldSelectors = {
+        inst_type: "#inst_type_select",
+        macro_event: "#macro_event",
+        polity: "#polity",
+        ra_check: "#ra_check_select",
+        source: "#source"
+      };
+      if (fieldSelectors[token.kind]) {
+        removeSelectValues(jQuery(fieldSelectors[token.kind]), [token.value]);
+      }
+
+      if (token.kind === "is_macro_event") {
+        const $selectedMacroevent = jQuery(
+          'input[name="is_macro_event"]:checked'
+        );
+        if ($selectedMacroevent.val() === token.value) {
+          jQuery("#is_macro_event_all").prop("checked", true).trigger("change");
+        }
+      }
     }
 
     function getRequiredRaCheckValues() {
@@ -1174,16 +1267,25 @@
       }
     });
 
-    jQuery("[data-instability-excluded-action]").on("click", function () {
-      const action = jQuery(this).data("instability-excluded-action");
-      if (action === "default") {
+    jQuery("[data-instability-quick-action]").on("click", function () {
+      const action = jQuery(this).data("instability-quick-action");
+      if (action === "exclude-invalid") {
         setExcludedRaChecks(getDefaultExcludedRaCheckIds(), "good");
-      } else if (action === "all") {
-        setExcludedRaChecks(getAllExcludedRaCheckIds(), "good");
-      } else if (action === "clear") {
+      } else if (action === "include-invalid") {
         setExcludedRaChecks([], "");
+      } else if (action === "only-llm") {
+        setSourceFilter(["llm"]);
+      } else if (action === "only-manual") {
+        setSourceFilter(["manual"]);
+        removeAllTokenValuesByKind("selected_batch");
+      } else if (action === "all-sources") {
+        setSourceFilter([]);
+      } else if (action === "all-batches") {
+        removeAllTokenValuesByKind("selected_batch");
+      } else {
+        return;
       }
-      cleanupInstabilityChoices();
+      $filterForm.get(0).requestSubmit();
     });
 
     $raCheckSelect.on("select2:select", function (event) {
@@ -1207,6 +1309,26 @@
       if (selectedToken && selectedToken.kind === "ra_check") {
         removeExcludedRaCheckValues([selectedToken.value]);
       }
+    });
+
+    $tokenFilter.on("select2:unselect", function (event) {
+      const tokenId = event.params && event.params.data && event.params.data.id;
+      removeTokenFromBackedField(getTokenParts(tokenId));
+    });
+
+    $instabilitySelects.on("select2:unselect", function (event) {
+      const value = event.params && event.params.data && event.params.data.id;
+      const kind = this.name;
+      if (kind && value !== undefined) {
+        removeTokenValuesByKind(kind, [value]);
+      }
+    });
+
+    jQuery('input[name="is_macro_event"]').on("change", function () {
+      removeTokenValuesByKind(
+        "is_macro_event",
+        getTokenValuesByKind("is_macro_event")
+      );
     });
 
     function tokenToParam(tokenId) {
@@ -1235,6 +1357,22 @@
       return { name: tokenParamMap[kind], value: value };
     }
 
+    function formHasParamValue($form, name, value) {
+      return $form.find("[name]").filter(function () {
+        if (this.disabled || this.name !== name) {
+          return false;
+        }
+        if ((this.type === "radio" || this.type === "checkbox") && !this.checked) {
+          return false;
+        }
+        const fieldValues = jQuery(this).val();
+        if (Array.isArray(fieldValues)) {
+          return fieldValues.map(String).includes(String(value));
+        }
+        return String(fieldValues || "") === String(value);
+      }).length > 0;
+    }
+
     jQuery(".instability-filter-panel form").on("submit", function () {
       const $form = jQuery(this);
       $form.find("[data-instability-token-param='true']").remove();
@@ -1242,6 +1380,9 @@
       ($tokenFilter.val() || []).forEach(function (tokenId) {
         const param = tokenToParam(tokenId);
         if (!param) {
+          return;
+        }
+        if (formHasParamValue($form, param.name, param.value)) {
           return;
         }
         jQuery("<input>", {
@@ -1259,6 +1400,16 @@
         $rowQuality.val("good");
       }
 
+      $form.find("#year_from_min, #year_to_max").each(function () {
+        jQuery(this).prop("disabled", !jQuery(this).val());
+      });
+      const $selectedMacroevent = $form.find(
+        'input[name="is_macro_event"]:checked'
+      );
+      if (!$selectedMacroevent.val()) {
+        $selectedMacroevent.prop("disabled", true);
+      }
+
       if ($rowQuality.val() === "good") {
         jQuery("<input>", {
           type: "hidden",
@@ -1267,6 +1418,7 @@
           "data-instability-excluded-mode": "true"
         }).appendTo($form);
       } else {
+        $rowQuality.prop("disabled", true);
         $excludedRaCheckSelect.prop("disabled", true);
       }
     });

--- a/seshat/apps/core/templates/core/partials/_instability_list_filters.html
+++ b/seshat/apps/core/templates/core/partials/_instability_list_filters.html
@@ -1,0 +1,446 @@
+{% load custom_filters %}
+
+<style>
+  .instability-filter-panel {
+    background:
+      linear-gradient(135deg, rgba(246, 127, 127, 0.08), rgba(242, 199, 119, 0.12), rgba(151, 230, 151, 0.1)),
+      #fffdf2;
+  }
+
+  .instability-filter-summary {
+    position: sticky;
+    top: 55px;
+    z-index: 920;
+    background: rgba(255, 253, 242, 0.95);
+    border: 1px solid rgba(120, 40, 35, 0.14);
+    border-radius: 12px;
+    box-shadow: 0 8px 20px rgba(120, 40, 35, 0.08);
+    padding: 0.65rem;
+  }
+
+  .instability-filter-tabs {
+    border-bottom-color: rgba(120, 40, 35, 0.18);
+  }
+
+  .instability-filter-tabs .nav-link {
+    color: #5f6b76;
+    border: 1px solid transparent;
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    font-weight: 700;
+    padding: 0.45rem 0.8rem;
+  }
+
+  .instability-filter-tabs .nav-link.active {
+    color: #212529;
+    background: rgba(255, 255, 255, 0.86);
+    border-color: rgba(120, 40, 35, 0.18) rgba(120, 40, 35, 0.18) rgba(255, 255, 255, 0.86);
+  }
+
+  .instability-filter-card {
+    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid rgba(120, 40, 35, 0.14);
+    border-top: 0;
+    border-radius: 0 0 12px 12px;
+    padding: 0.75rem;
+  }
+
+  .instability-filter-card-title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border-bottom: 1px solid rgba(120, 40, 35, 0.12);
+    padding-bottom: 0.35rem;
+    margin-bottom: 0.6rem;
+  }
+
+  .instability-filter-help {
+    color: #6c757d;
+    font-size: 0.76rem;
+    line-height: 1.2;
+    margin-top: 0.25rem;
+  }
+
+  .instability-quick-row {
+    background: rgba(255, 255, 255, 0.42);
+    border-radius: 10px;
+    padding: 0.35rem;
+  }
+
+  .instability-summary-search {
+    flex: 1 1 18rem;
+    min-width: min(100%, 18rem);
+  }
+
+  .instability-summary-batch {
+    flex: 1 1 18rem;
+    min-width: min(100%, 18rem);
+  }
+
+  .instability-summary-actions {
+    flex: 0 0 auto;
+  }
+
+  .instability-filter-panel .select2-container {
+    width: 100% !important;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple {
+    min-height: 42px;
+    max-height: 118px;
+    overflow-y: auto;
+    padding: 4px 6px;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__rendered {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 0;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__choice {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    margin: 0;
+    padding: 2px 1.75rem 2px 8px;
+    border-color: rgba(25, 135, 84, 0.75);
+    background: rgba(151, 230, 151, 0.45);
+    color: #123f18;
+    white-space: normal;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+    position: absolute;
+    top: 50%;
+    right: 4px;
+    left: auto;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 1.15rem;
+    min-width: 1.15rem;
+    height: 1.15rem;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 999px;
+    color: #0f5132;
+    float: none;
+    font-weight: 700;
+    line-height: 1;
+    text-decoration: none;
+    transform: translateY(-50%);
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+    background: rgba(15, 81, 50, 0.14);
+    color: #842029;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__clear {
+    display: none !important;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-search--inline .select2-search__field {
+    min-width: 16rem;
+    margin-top: 3px;
+  }
+
+  .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
+    color: #6c757d;
+    margin-top: 3px;
+  }
+</style>
+
+<div class="border border-secondary rounded px-3 pt-3 mb-2 instability-filter-panel">
+    <form method="get" class="row g-2 mb-3">
+        <div class="col-12 d-flex flex-wrap justify-content-between align-items-center gap-2 pb-1">
+            <div>
+                <div class="d-flex flex-wrap align-items-center gap-2">
+                    <strong class="text-dark">Filter Instability Events</strong>
+                    <span class="badge rounded-pill bg-colorful border text-dark">
+                        {% if record_count is not None %}
+                            {{ record_count }} matching
+                        {% else %}
+                            {{ object_list|length }} matching
+                        {% endif %}
+                    </span>
+                    {% if active_filter_count %}
+                        <span class="badge rounded-pill bg-warning-light text-dark">{{ active_filter_count }} filter{{ active_filter_count|pluralize }} active</span>
+                    {% else %}
+                        <span class="badge rounded-pill bg-absent-light text-secondary">No filters active</span>
+                    {% endif %}
+                </div>
+                <div class="small text-secondary">
+                    Build a research set by combining scope, source, quality, classification, and time filters.
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12">
+            <div class="instability-filter-summary">
+                <div class="d-flex flex-wrap justify-content-between align-items-end gap-2">
+                    <div class="d-flex flex-wrap align-items-center gap-2 instability-quick-row">
+                        <span class="small fw-semibold text-secondary me-1">Common views</span>
+                        <a href="?{% query_transform request row_quality='good' %}" class="btn btn-sm {% if selected_row_quality == 'good' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                            Exclude invalid rows
+                        </a>
+                        {% if selected_row_quality == 'good' %}
+                            <a href="?{% query_transform request row_quality=None %}" class="btn btn-sm btn-outline-secondary">Include invalid rows</a>
+                        {% endif %}
+                        <a href="?{% query_transform request source='llm' %}" class="btn btn-sm {% if selected_source == 'llm' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                            Only LLM
+                        </a>
+                        <a href="?{% query_transform request source='manual' selected_batch=None %}" class="btn btn-sm {% if selected_source == 'manual' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                            Only manual
+                        </a>
+                        {% if selected_source_values %}
+                            <a href="?{% query_transform request source=None selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All sources</a>
+                        {% endif %}
+                        {% if selected_batch_values %}
+                            <a href="?{% query_transform request selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All batches</a>
+                        {% endif %}
+                    </div>
+
+                    <div class="instability-summary-search">
+                        <label for="searched_name" class="small fw-semibold text-secondary mb-1">Search events</label>
+                        <input type="text" name="searched_name" id="searched_name" class="form-control form-control-sm" value="{{ name_query }}" placeholder="Search event names">
+                    </div>
+
+                    <div class="instability-summary-batch">
+                        <label for="selected_batch" class="small fw-semibold text-secondary mb-1">LLM batches</label>
+                        <select name="selected_batch" id="selected_batch" class="form-select js-instability-multiple" multiple data-placeholder="All LLM batches">
+                          {% for batch, count in batch_filter_choices %}
+                            <option value="{{ batch }}" {% if batch in selected_batch_values %}selected{% endif %}>
+                              {{ batch }} - {{ count }}
+                            </option>
+                          {% endfor %}
+                        </select>
+                        <div class="instability-filter-help mb-0">Batch filters always limit results to LLM rows.</div>
+                    </div>
+
+                    <div class="d-flex flex-wrap align-items-center gap-2 instability-summary-actions">
+                        <button type="submit" class="btn btn-sm fw-bold bg-colorful-light">
+                            <i class="fa-solid fa-filter"></i> Apply
+                        </button>
+                        <a href="?" class="btn btn-outline-danger btn-sm fw-semibold text-nowrap">Clear All</a>
+                    </div>
+                </div>
+
+                {% include "core/partials/_instability_active_filter_chips.html" %}
+            </div>
+        </div>
+
+        <div class="col-12 pt-2">
+            <ul class="nav nav-tabs instability-filter-tabs" id="instabilityFilterTabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="instability-scope-tab" data-bs-toggle="tab" data-bs-target="#instability-scope-pane" type="button" role="tab" aria-controls="instability-scope-pane" aria-selected="true">
+                        Scope
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="instability-source-tab" data-bs-toggle="tab" data-bs-target="#instability-source-pane" type="button" role="tab" aria-controls="instability-source-pane" aria-selected="false">
+                        Source & Review
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="instability-classification-tab" data-bs-toggle="tab" data-bs-target="#instability-classification-pane" type="button" role="tab" aria-controls="instability-classification-pane" aria-selected="false">
+                        Classification
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="instability-time-tab" data-bs-toggle="tab" data-bs-target="#instability-time-pane" type="button" role="tab" aria-controls="instability-time-pane" aria-selected="false">
+                        Time
+                    </button>
+                </li>
+            </ul>
+
+            <div class="tab-content" id="instabilityFilterTabContent">
+                <div class="tab-pane fade show active" id="instability-scope-pane" role="tabpanel" aria-labelledby="instability-scope-tab" tabindex="0">
+                    <div class="instability-filter-card">
+                        <div class="instability-filter-card-title">
+                            <span class="small fw-bold text-dark">Scope</span>
+                            <span class="small text-secondary">Choose where and which umbrella event to inspect.</span>
+                        </div>
+                        <div class="row g-2">
+                            <div class="col-md-6 pb-2">
+                                <label for="polity" class="text-secondary">Polities <small class="text-secondary">(matching: {{ polities|length }})</small></label>
+                                <select name="polity" id="polity" class="form-select js-instability-multiple" multiple data-placeholder="Search polities, then choose one or more">
+                                  {% for p in polities %}
+                                    <option value="{{ p.id }}" {% if p.id|stringformat:"s" in selected_polity_ids %}selected{% endif %}>
+                                        {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}] - {{ p.event_count }}
+                                    </option>
+                                  {% endfor %}
+                                </select>
+                                <div class="instability-filter-help">Type to search polities. Use the x inside a green chip to remove only that polity.</div>
+                            </div>
+
+                            <div class="col-md-6 pb-2">
+                                <label for="macro_event" class="text-secondary">Umbrella Events</label>
+                                <select name="macro_event" id="macro_event" class="form-select js-instability-multiple" multiple data-placeholder="Search umbrella events">
+                                  {% for event, count in macro_events_with_counts %}
+                                    <option value="{{ event }}" {% if event in selected_macro_events %}selected{% endif %}>
+                                       {{ event }} - {{ count }}
+                                    </option>
+                                  {% endfor %}
+                                </select>
+                                <div class="instability-filter-help">Use this for clusters of related instability events.</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade" id="instability-source-pane" role="tabpanel" aria-labelledby="instability-source-tab" tabindex="0">
+                    <div class="instability-filter-card">
+                        <div class="instability-filter-card-title">
+                            <span class="small fw-bold text-dark">Source & Review State</span>
+                            <span class="small text-secondary">Control data origin and exclude invalid review outcomes.</span>
+                        </div>
+                        <div class="row g-2">
+                            <div class="col-md-4 pb-2">
+                                <label for="source" class="text-secondary">Sources</label>
+                                <select name="source" id="source" class="form-select js-instability-multiple" multiple data-placeholder="All sources">
+                                  {% for value, label, count in source_filter_choices %}
+                                    <option value="{{ value }}" {% if value in selected_source_values %}selected{% endif %}>{{ label }} - {{ count }}</option>
+                                  {% endfor %}
+                                </select>
+                                <div class="instability-filter-help">Select LLM, manual, or both.</div>
+                            </div>
+
+                            <div class="col-md-4 pb-2">
+                                <label for="row_quality" class="text-secondary">Invalid rows</label>
+                                <select name="row_quality" id="row_quality" class="form-select js-example-basic-single">
+                                  <option value="">Include all rows</option>
+                                  <option value="good" {% if selected_row_quality == "good" %}selected{% endif %}>Exclude invalid rows</option>
+                                </select>
+                                <div class="instability-filter-help">Invalid means Bad Row, Duplicate, Not Instability Event, or External Event.</div>
+                            </div>
+
+                            <div class="col-md-4 pb-2">
+                                <label for="is_macro_event" class="text-secondary">Macroevent Record</label>
+                                <select name="is_macro_event" id="is_macro_event" class="form-select js-example-basic-single">
+                                  <option value="">All</option>
+                                  <option value="true" {% if selected_is_macro_event == "true" %}selected{% endif %}>True</option>
+                                  <option value="false" {% if selected_is_macro_event == "false" %}selected{% endif %}>False</option>
+                                </select>
+                                <div class="instability-filter-help">Limit to rows marked as macroevent records, or exclude them.</div>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade" id="instability-classification-pane" role="tabpanel" aria-labelledby="instability-classification-tab" tabindex="0">
+                    <div class="instability-filter-card">
+                        <div class="instability-filter-card-title">
+                            <span class="small fw-bold text-dark">Classification</span>
+                            <span class="small text-secondary">Narrow by event type, review labels, intensity, or extent.</span>
+                        </div>
+                        <div class="row g-2">
+                            <div class="col-md-4 pb-2">
+                                <label for="inst_type_select" class="text-secondary d-block">Event Types</label>
+                                <select id="inst_type_select" name="inst_type" class="form-select js-instability-multiple" multiple data-placeholder="Search event types">
+                                  {% for type in instability_types %}
+                                    <option value="{{ type.id }}" {% if type.id|stringformat:"s" in selected_inst_type_ids %}selected{% endif %}>
+                                      {{ type.name }} - {{ type.event_count }}
+                                    </option>
+                                  {% endfor %}
+                                </select>
+                                <div class="instability-filter-help">Select one or more instability categories.</div>
+                            </div>
+
+                            <div class="col-md-4 pb-2">
+                                <label for="ra_check_select" class="text-secondary d-block">Researcher Checks</label>
+                                <select id="ra_check_select" name="ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Search researcher checks">
+                                  {% for check in check_choices %}
+                                    <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_ra_check_ids %}selected{% endif %}>
+                                      {{ check.name }} - {{ check.event_count }}
+                                    </option>
+                                  {% endfor %}
+                                </select>
+                                <div class="instability-filter-help">Correction labels stay searchable; invalid labels can be excluded above.</div>
+                            </div>
+
+                            <div class="col-md-4 pb-2">
+                                <label for="inst_intensity_select" class="text-secondary">Intensity</label>
+                                <select id="inst_intensity_select" name="inst_intensity" class="form-select js-instability-multiple" multiple data-placeholder="All intensities">
+                                  {% for val, label, count in inst_intensity_filter_choices %}
+                                    <option value="{{ val }}" {% if val in selected_inst_intensity_values %}selected{% endif %}>
+                                      {{ label }} - {{ count }}
+                                    </option>
+                                  {% endfor %}
+                                </select>
+                            </div>
+
+                            <div class="col-md-4 pb-2">
+                                <label for="inst_extent_select" class="text-secondary">Extent</label>
+                                <select id="inst_extent_select" name="inst_extent" class="form-select js-instability-multiple" multiple data-placeholder="All extents">
+                                  {% for val, label, count in inst_extent_filter_choices %}
+                                    <option value="{{ val }}" {% if val in selected_inst_extent_values %}selected{% endif %}>
+                                      {{ label }} - {{ count }}
+                                    </option>
+                                  {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade" id="instability-time-pane" role="tabpanel" aria-labelledby="instability-time-tab" tabindex="0">
+                    <div class="instability-filter-card">
+                        <div class="instability-filter-card-title">
+                            <span class="small fw-bold text-dark">Time</span>
+                            <span class="small text-secondary">Constrain the effective year range.</span>
+                        </div>
+                        <div class="row g-2">
+                            <div class="col-md-2 pb-2">
+                                <label class="text-secondary" for="year_from_min">Start Year</label>
+                                <input type="number" name="year_from_min" id="year_from_min" class="form-control" value="{{ request.GET.year_from_min }}" placeholder="Min">
+                            </div>
+
+                            <div class="col-md-2 pb-2">
+                                <label class="text-secondary" for="year_to_max">End Year</label>
+                                <input type="number" name="year_to_max" id="year_to_max" class="form-control" value="{{ request.GET.year_to_max }}" placeholder="Max">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+      </form>
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    if (!window.jQuery || !jQuery.fn.select2) {
+      return;
+    }
+
+    const $instabilitySelects = jQuery(".js-instability-multiple");
+
+    $instabilitySelects.each(function () {
+      const $select = jQuery(this);
+      $select.select2({
+        allowClear: false,
+        closeOnSelect: false,
+        placeholder: $select.data("placeholder") || "Search and select",
+        width: "100%"
+      });
+    });
+
+    function cleanupInstabilityChoices() {
+      jQuery(".instability-filter-panel .select2-selection__choice").removeAttr("title");
+      jQuery(".instability-filter-panel .select2-selection__clear").remove();
+    }
+
+    $instabilitySelects.on("change select2:select select2:unselect select2:open", cleanupInstabilityChoices);
+    document.querySelectorAll('[data-bs-toggle="tab"]').forEach(function (tabButton) {
+      tabButton.addEventListener("shown.bs.tab", cleanupInstabilityChoices);
+    });
+    cleanupInstabilityChoices();
+  });
+</script>

--- a/seshat/apps/core/templates/core/partials/_instability_list_filters.html
+++ b/seshat/apps/core/templates/core/partials/_instability_list_filters.html
@@ -153,44 +153,157 @@
     background: rgba(120, 40, 35, 0.09);
   }
 
-  .instability-filter-tabs {
-    border-bottom: 0;
-    gap: 0.35rem;
-  }
-
-  .instability-filter-tabs .nav-link {
-    color: var(--instability-muted);
-    background: rgba(255, 255, 255, 0.45);
-    border: 1px solid transparent;
-    border-radius: 999px;
-    font-weight: 700;
-    padding: 0.5rem 0.9rem;
-  }
-
-  .instability-filter-tabs .nav-link.active {
-    color: var(--instability-ink);
-    background: #fffdfa;
-    border-color: var(--instability-line);
-    box-shadow: 0 8px 20px rgba(89, 54, 32, 0.08);
+  .instability-filter-sections {
+    display: grid;
+    gap: 0.65rem;
   }
 
   .instability-filter-card {
     background: rgba(255, 253, 250, 0.82);
     border: 1px solid var(--instability-line);
     border-radius: 16px;
-    margin-top: 0.55rem;
-    padding: 0.85rem;
+    box-shadow: 0 10px 24px rgba(89, 54, 32, 0.05);
+    overflow: hidden;
+  }
+
+  .instability-filter-card-toggle {
+    align-items: center;
+    background: rgba(255, 253, 250, 0.72);
+    border: 0;
+    color: inherit;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 0.85rem;
+    text-align: left;
+    width: 100%;
+  }
+
+  .instability-filter-card-toggle:focus {
+    outline: 2px solid rgba(15, 118, 110, 0.3);
+    outline-offset: -2px;
   }
 
   .instability-filter-card-title {
-    display: flex;
-    flex-wrap: wrap;
     align-items: baseline;
-    justify-content: space-between;
-    gap: 0.5rem;
-    border-bottom: 1px solid rgba(120, 40, 35, 0.1);
-    padding-bottom: 0.35rem;
-    margin-bottom: 0.6rem;
+    display: flex;
+    flex: 1 1 16rem;
+    flex-wrap: wrap;
+    gap: 0.45rem 0.8rem;
+    min-width: 0;
+  }
+
+  .instability-filter-card-summary {
+    align-items: center;
+    color: var(--instability-muted);
+    display: flex;
+    flex: 1 1 18rem;
+    flex-wrap: wrap;
+    font-size: 0.76rem;
+    gap: 0.35rem;
+    justify-content: flex-end;
+  }
+
+  .instability-filter-card-summary .badge {
+    border: 1px solid rgba(120, 40, 35, 0.1);
+    font-weight: 700;
+  }
+
+  .instability-filter-card-chevron {
+    color: var(--instability-muted);
+    transition: transform 0.18s ease;
+  }
+
+  .instability-filter-card-toggle[aria-expanded="true"] .instability-filter-card-chevron {
+    transform: rotate(180deg);
+  }
+
+  .instability-filter-card-body {
+    border-top: 1px solid rgba(120, 40, 35, 0.1);
+    padding: 0.85rem;
+  }
+
+  .instability-filter-field {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .instability-filter-field > label,
+  .instability-toggle-field legend {
+    color: var(--instability-muted);
+    font-weight: 700;
+    line-height: 1.15;
+    margin-bottom: 0.32rem;
+  }
+
+  .instability-toggle-field {
+    border: 0;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    margin: 0;
+    min-width: 0;
+    padding: 0;
+  }
+
+  .instability-toggle-field legend {
+    float: none;
+    font-size: inherit;
+    width: auto;
+  }
+
+  .instability-choice-toggle {
+    background: rgba(255, 255, 255, 0.74);
+    border: 1px solid rgba(120, 40, 35, 0.16);
+    border-radius: 14px;
+    display: grid;
+    gap: 0.28rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    min-height: 42px;
+    padding: 0.26rem;
+  }
+
+  .instability-choice-toggle input {
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+  }
+
+  .instability-choice-toggle label {
+    align-items: center;
+    border: 1px solid transparent;
+    border-radius: 11px;
+    color: var(--instability-muted);
+    cursor: pointer;
+    display: flex;
+    font-size: 0.82rem;
+    font-weight: 700;
+    justify-content: center;
+    line-height: 1.15;
+    margin: 0;
+    min-height: 2rem;
+    padding: 0.36rem 0.55rem;
+    text-align: center;
+    transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+  }
+
+  .instability-choice-toggle label:hover {
+    background: rgba(15, 118, 110, 0.08);
+    color: var(--instability-ink);
+  }
+
+  .instability-choice-toggle input:focus-visible + label {
+    outline: 2px solid rgba(15, 118, 110, 0.34);
+    outline-offset: 2px;
+  }
+
+  .instability-choice-toggle input:checked + label {
+    background: linear-gradient(135deg, rgba(15, 118, 110, 0.15), rgba(244, 183, 112, 0.16));
+    border-color: rgba(15, 118, 110, 0.36);
+    box-shadow: 0 6px 14px rgba(15, 118, 110, 0.12);
+    color: #10433e;
   }
 
   .instability-filter-help {
@@ -198,6 +311,36 @@
     font-size: 0.76rem;
     line-height: 1.2;
     margin-top: 0.25rem;
+  }
+
+  .instability-filter-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.45rem;
+  }
+
+  .instability-filter-actions .btn {
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 0.22rem 0.55rem;
+  }
+
+  .instability-filter-panel .form-control {
+    min-height: 42px;
+    border: 1px solid rgba(120, 40, 35, 0.16);
+    border-radius: 12px;
+    background: #fff;
+    color: var(--instability-ink);
+    box-shadow: none;
+    padding: 0.42rem 0.65rem;
+  }
+
+  .instability-filter-panel .form-control:focus {
+    border-color: rgba(15, 118, 110, 0.42);
+    box-shadow: 0 0 0 0.18rem rgba(15, 118, 110, 0.12);
   }
 
   .instability-filter-panel .select2-container {
@@ -214,7 +357,16 @@
     background: #fff;
   }
 
+  .instability-filter-field .select2-container--default .select2-selection--multiple {
+    align-items: center;
+    display: flex;
+    min-height: 42px;
+    max-height: 96px;
+  }
+
   .instability-global-filter .select2-container--default .select2-selection--multiple {
+    align-items: center;
+    display: flex;
     min-height: 58px;
     max-height: 140px;
     padding: 8px 10px;
@@ -223,11 +375,22 @@
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
   }
 
+  .instability-global-filter .select2-container--default .select2-selection--multiple .select2-selection__rendered {
+    align-items: center;
+    min-height: 2.4rem;
+  }
+
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__rendered {
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
+    min-width: 0;
     padding: 0;
+  }
+
+  .instability-filter-field .select2-container--default .select2-selection--multiple .select2-selection__rendered {
+    align-items: center;
+    min-height: 2rem;
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__choice {
@@ -281,9 +444,31 @@
     color: var(--instability-ink);
   }
 
+  .instability-filter-field .select2-container--default .select2-search--inline .select2-search__field {
+    height: 2rem;
+    line-height: 2rem;
+    margin-top: 0;
+  }
+
+  .instability-global-filter .select2-container--default .select2-search--inline .select2-search__field {
+    height: 2.4rem;
+    line-height: 2.4rem;
+    margin-top: 0;
+  }
+
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
     color: #6c757d;
     margin-top: 3px;
+  }
+
+  .instability-filter-field .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
+    line-height: 2rem;
+    margin-top: 0;
+  }
+
+  .instability-global-filter .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
+    line-height: 2.4rem;
+    margin-top: 0;
   }
 
   .instability-filter-panel .select2-dropdown,
@@ -315,6 +500,9 @@
   .instability-filter-panel .select2-results__group,
   .instability-filter-dropdown .select2-results__group {
     background: #fffdfa !important;
+    clear: both !important;
+    display: block !important;
+    line-height: 1.2;
     padding: 0.72rem 0.9rem 0.35rem;
     color: var(--instability-muted, #70655f) !important;
     font-size: 0.72rem;
@@ -327,15 +515,31 @@
   .instability-filter-dropdown .select2-results__option {
     background: #fffdfa !important;
     color: var(--instability-ink, #2d2520) !important;
+    box-sizing: border-box;
     display: block !important;
     float: none !important;
+    line-height: normal;
     padding: 0.62rem 0.9rem;
   }
 
   .instability-filter-panel .select2-results__option[role="group"],
   .instability-filter-dropdown .select2-results__option[role="group"] {
     background: #fffdfa !important;
+    clear: both !important;
+    display: block !important;
+    overflow: visible !important;
     padding: 0 !important;
+  }
+
+  .instability-filter-dropdown .select2-results__options--nested > .select2-results__option {
+    border-top: 1px solid rgba(120, 40, 35, 0.08);
+    clear: both !important;
+    min-height: 4.2rem;
+    padding: 0.76rem 0.9rem !important;
+  }
+
+  .instability-filter-dropdown .select2-results__options--nested > .select2-results__option:first-child {
+    border-top: 0;
   }
 
   .instability-filter-panel .select2-results__option--highlighted[aria-selected],
@@ -360,7 +564,7 @@
     grid-template-columns: minmax(5.5rem, 7rem) minmax(0, 1fr);
     gap: 0.65rem;
     align-items: start;
-    min-height: 2.4rem;
+    min-height: 2.75rem;
     width: 100%;
   }
 
@@ -404,6 +608,12 @@
       justify-content: flex-start;
     }
   }
+
+  @media (max-width: 767px) {
+    .instability-choice-toggle {
+      grid-template-columns: 1fr;
+    }
+  }
 </style>
 
 <div class="border border-secondary rounded px-3 pt-3 mb-2 instability-filter-panel">
@@ -436,7 +646,7 @@
                 <div class="instability-summary-main">
                     <div class="instability-global-filter">
                         <label for="global_filter_tokens" class="small fw-semibold text-secondary mb-1">Search & add filters</label>
-                        <select id="global_filter_tokens" class="form-select js-instability-token-filter" multiple data-ajax-url="{% url 'instability_event-filter-tokens' %}" data-placeholder="Search events, polities, batches, sources, types, checks, or macroevent state">
+                        <select id="global_filter_tokens" class="form-select js-instability-token-filter" multiple data-ajax-url="{% url 'instability_event-filter-tokens' %}" data-placeholder="Search events, polities, batches, sources, types, checks, macro events, or normal events">
                           {% for token in selected_global_filter_tokens %}
                             <option value="{{ token.token_id }}" selected>{{ token.label }}</option>
                           {% endfor %}
@@ -460,14 +670,20 @@
                     {% if selected_row_quality == 'good' %}
                         <a href="?{% query_transform request row_quality=None excluded_ra_check=None excluded_ra_check_mode=None %}" class="btn btn-sm btn-outline-secondary">Include invalid rows</a>
                     {% endif %}
-                    <a href="?{% query_transform request source='llm' %}" class="btn btn-sm {% if selected_source == 'llm' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                    <a href="?{% query_transform request source='llm' %}" class="btn btn-sm {% if explicit_selected_source == 'llm' and not batch_filter_forces_llm %}btn-dark{% else %}btn-outline-secondary{% endif %}">
                         Only LLM
                     </a>
-                    <a href="?{% query_transform request source='manual' selected_batch=None %}" class="btn btn-sm {% if selected_source == 'manual' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
-                        Only manual
-                    </a>
-                    {% if selected_source_values %}
-                        <a href="?{% query_transform request source=None selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All sources</a>
+                    {% if batch_filter_forces_llm %}
+                        <span class="btn btn-sm btn-outline-secondary disabled" aria-disabled="true" title="Batch filters are LLM-only. Clear batches before selecting manual rows." data-instability-source-conflict="batch">
+                            Only manual
+                        </span>
+                    {% else %}
+                        <a href="?{% query_transform request source='manual' selected_batch=None %}" class="btn btn-sm {% if explicit_selected_source == 'manual' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                            Only manual
+                        </a>
+                    {% endif %}
+                    {% if explicit_selected_source_values and not batch_filter_forces_llm %}
+                        <a href="?{% query_transform request source=None %}" class="btn btn-sm btn-outline-secondary" data-instability-clear-sources="true">All sources</a>
                     {% endif %}
                     {% if selected_batch_values %}
                         <a href="?{% query_transform request selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All batches</a>
@@ -479,191 +695,247 @@
         </div>
 
         <div class="col-12 pt-2">
-            <ul class="nav nav-tabs instability-filter-tabs" id="instabilityFilterTabs" role="tablist">
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link active" id="instability-scope-tab" data-bs-toggle="tab" data-bs-target="#instability-scope-pane" type="button" role="tab" aria-controls="instability-scope-pane" aria-selected="true">
-                        Scope
-                    </button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="instability-source-tab" data-bs-toggle="tab" data-bs-target="#instability-source-pane" type="button" role="tab" aria-controls="instability-source-pane" aria-selected="false">
-                        Source & Review
-                    </button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="instability-classification-tab" data-bs-toggle="tab" data-bs-target="#instability-classification-pane" type="button" role="tab" aria-controls="instability-classification-pane" aria-selected="false">
-                        Classification
-                    </button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="instability-time-tab" data-bs-toggle="tab" data-bs-target="#instability-time-pane" type="button" role="tab" aria-controls="instability-time-pane" aria-selected="false">
-                        Time
-                    </button>
-                </li>
-            </ul>
-
-            <div class="tab-content" id="instabilityFilterTabContent">
-                <div class="tab-pane fade show active" id="instability-scope-pane" role="tabpanel" aria-labelledby="instability-scope-tab" tabindex="0">
-                    <div class="instability-filter-card">
-                        <div class="instability-filter-card-title">
+            <div class="instability-filter-sections" id="instabilityFilterSections">
+                <section class="instability-filter-card">
+                    <button class="instability-filter-card-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#instability-scope-section" aria-controls="instability-scope-section" aria-expanded="{% if selected_polity_ids or selected_macro_events %}true{% else %}false{% endif %}">
+                        <span class="instability-filter-card-title">
                             <span class="small fw-bold text-dark">Scope</span>
                             <span class="small text-secondary">Choose where and which umbrella event to inspect.</span>
-                        </div>
-                        <div class="row g-2">
-                            <div class="col-md-6 pb-2">
-                                <label for="polity" class="text-secondary">Polities <small class="text-secondary">(matching: {{ polities|length }})</small></label>
-                                <select name="polity" id="polity" class="form-select js-instability-multiple" multiple data-placeholder="Search polities, then choose one or more">
-                                  {% for p in polities %}
-                                    <option value="{{ p.id }}" {% if p.id|stringformat:"s" in selected_polity_ids %}selected{% endif %}>
-                                        {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}] - {{ p.event_count }}
-                                    </option>
-                                  {% endfor %}
-                                </select>
-                                <div class="instability-filter-help">Type to search polities. Use the x inside a green chip to remove only that polity.</div>
-                            </div>
+                        </span>
+                        <span class="instability-filter-card-summary">
+                            {% if selected_polity_ids %}
+                                <span class="badge rounded-pill bg-success-light text-dark">{{ selected_polity_ids|length }} polities</span>
+                            {% else %}
+                                <span>{{ polities|length }} matching polities</span>
+                            {% endif %}
+                            {% if selected_macro_events %}
+                                <span class="badge rounded-pill bg-secondary-light text-dark">{{ selected_macro_events|length }} umbrella events</span>
+                            {% else %}
+                                <span>{{ macro_events|length }} umbrella events</span>
+                            {% endif %}
+                        </span>
+                        <i class="fa-solid fa-chevron-down instability-filter-card-chevron"></i>
+                    </button>
+                    <div id="instability-scope-section" class="collapse {% if selected_polity_ids or selected_macro_events %}show{% endif %}">
+                        <div class="instability-filter-card-body">
+                            <div class="row g-2">
+                                <div class="col-md-6 pb-2 instability-filter-field">
+                                    <label for="polity" class="text-secondary">Polities <small class="text-secondary">(matching: {{ polities|length }})</small></label>
+                                    <select name="polity" id="polity" class="form-select js-instability-multiple" multiple data-placeholder="Search polities">
+                                      {% for p in polities %}
+                                        <option value="{{ p.id }}" {% if p.id|stringformat:"s" in selected_polity_ids %}selected{% endif %}>
+                                            {{ p.long_name }} ({{ p.new_name }}) [{{ p.formatted_years_text }}] - {{ p.event_count }}
+                                        </option>
+                                      {% endfor %}
+                                    </select>
+                                    <div class="instability-filter-help">Type to search polities. Use the x inside a green chip to remove only that polity.</div>
+                                </div>
 
-                            <div class="col-md-6 pb-2">
-                                <label for="macro_event" class="text-secondary">Umbrella Events</label>
-                                <select name="macro_event" id="macro_event" class="form-select js-instability-multiple" multiple data-placeholder="Search umbrella events">
-                                  {% for event, count in macro_events_with_counts %}
-                                    <option value="{{ event }}" {% if event in selected_macro_events %}selected{% endif %}>
-                                       {{ event }} - {{ count }}
-                                    </option>
-                                  {% endfor %}
-                                </select>
-                                <div class="instability-filter-help">Use this for clusters of related instability events.</div>
+                                <div class="col-md-6 pb-2 instability-filter-field">
+                                    <label for="macro_event" class="text-secondary">Umbrella Events</label>
+                                    <select name="macro_event" id="macro_event" class="form-select js-instability-multiple" multiple data-placeholder="Search umbrella events">
+                                      {% for event, count in macro_events_with_counts %}
+                                        <option value="{{ event }}" {% if event in selected_macro_events %}selected{% endif %}>
+                                           {{ event }} - {{ count }}
+                                        </option>
+                                      {% endfor %}
+                                    </select>
+                                    <div class="instability-filter-help">Use this for clusters of related instability events.</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="instability-filter-card">
+                    <button class="instability-filter-card-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#instability-source-section" aria-controls="instability-source-section" aria-expanded="{% if selected_source_values or selected_batch_values or selected_is_macro_event %}true{% else %}false{% endif %}">
+                        <span class="instability-filter-card-title">
+                            <span class="small fw-bold text-dark">Source & Macroevent</span>
+                            <span class="small text-secondary">Control data origin and macroevent status.</span>
+                        </span>
+                        <span class="instability-filter-card-summary">
+                            {% if selected_batch_values %}
+                                <span class="badge rounded-pill bg-warning-light text-dark">LLM batches: {{ selected_batch_values|length }}</span>
+                            {% elif selected_source_values %}
+                                <span class="badge rounded-pill bg-warning-light text-dark">Sources: {{ selected_source_values|length }}</span>
+                            {% else %}
+                                <span>All sources</span>
+                            {% endif %}
+                            {% if selected_is_macro_event %}
+                                {% if selected_is_macro_event == "true" %}
+                                    <span class="badge rounded-pill bg-info-light text-dark">Macro events only</span>
+                                {% else %}
+                                    <span class="badge rounded-pill bg-info-light text-dark">Normal events only</span>
+                                {% endif %}
+                            {% else %}
+                                <span>All events</span>
+                            {% endif %}
+                        </span>
+                        <i class="fa-solid fa-chevron-down instability-filter-card-chevron"></i>
+                    </button>
+                    <div id="instability-source-section" class="collapse {% if selected_source_values or selected_batch_values or selected_is_macro_event %}show{% endif %}">
+                        <div class="instability-filter-card-body">
+                            <div class="row g-2">
+                                <div class="col-md-6 pb-2 instability-filter-field">
+                                    <label for="source" class="text-secondary">Sources</label>
+                                    <select name="source" id="source" class="form-select js-instability-multiple" multiple data-placeholder="All sources">
+                                      {% for value, label, count in source_filter_choices %}
+                                        <option value="{{ value }}" {% if value in selected_source_values %}selected{% endif %}>{{ label }} - {{ count }}</option>
+                                      {% endfor %}
+                                    </select>
+                                    <div class="instability-filter-help">Select LLM, manual, or both.</div>
+                                </div>
+
+                                <input type="hidden" name="row_quality" id="row_quality" value="{{ selected_row_quality }}">
+
+                                <div class="col-md-6 pb-2 instability-filter-field">
+                                    <fieldset class="instability-toggle-field">
+                                        <legend>Macroevent</legend>
+                                        <div class="instability-choice-toggle" role="radiogroup" aria-label="Macroevent filter">
+                                            <input type="radio" name="is_macro_event" id="is_macro_event_all" value="" {% if not selected_is_macro_event %}checked{% endif %}>
+                                            <label for="is_macro_event_all">All events</label>
+                                            <input type="radio" name="is_macro_event" id="is_macro_event_true" value="true" {% if selected_is_macro_event == "true" %}checked{% endif %}>
+                                            <label for="is_macro_event_true">Macro events</label>
+                                            <input type="radio" name="is_macro_event" id="is_macro_event_false" value="false" {% if selected_is_macro_event == "false" %}checked{% endif %}>
+                                            <label for="is_macro_event_false">Normal events</label>
+                                        </div>
+                                    </fieldset>
+                                    <div class="instability-filter-help">Choose whether to inspect macro events, normal events, or both.</div>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </section>
 
-                <div class="tab-pane fade" id="instability-source-pane" role="tabpanel" aria-labelledby="instability-source-tab" tabindex="0">
-                    <div class="instability-filter-card">
-                        <div class="instability-filter-card-title">
-                            <span class="small fw-bold text-dark">Source & Review State</span>
-                            <span class="small text-secondary">Control data origin and exclude invalid review outcomes.</span>
-                        </div>
-                        <div class="row g-2">
-                            <div class="col-md-4 pb-2">
-                                <label for="source" class="text-secondary">Sources</label>
-                                <select name="source" id="source" class="form-select js-instability-multiple" multiple data-placeholder="All sources">
-                                  {% for value, label, count in source_filter_choices %}
-                                    <option value="{{ value }}" {% if value in selected_source_values %}selected{% endif %}>{{ label }} - {{ count }}</option>
-                                  {% endfor %}
-                                </select>
-                                <div class="instability-filter-help">Select LLM, manual, or both.</div>
-                            </div>
-
-                            <div class="col-md-4 pb-2">
-                                <label for="row_quality" class="text-secondary">Invalid rows</label>
-                                <select name="row_quality" id="row_quality" class="form-select js-example-basic-single">
-                                  <option value="">Include all rows</option>
-                                  <option value="good" {% if selected_row_quality == "good" %}selected{% endif %}>Exclude invalid rows</option>
-                                </select>
-                                <div class="instability-filter-help">Default invalid labels are configurable in the Classification tab.</div>
-                            </div>
-
-                            <div class="col-md-4 pb-2">
-                                <label for="is_macro_event" class="text-secondary">Macroevent Record</label>
-                                <select name="is_macro_event" id="is_macro_event" class="form-select js-example-basic-single">
-                                  <option value="">All</option>
-                                  <option value="true" {% if selected_is_macro_event == "true" %}selected{% endif %}>True</option>
-                                  <option value="false" {% if selected_is_macro_event == "false" %}selected{% endif %}>False</option>
-                                </select>
-                                <div class="instability-filter-help">Limit to rows marked as macroevent records, or exclude them.</div>
-                            </div>
-
-                        </div>
-                    </div>
-                </div>
-
-                <div class="tab-pane fade" id="instability-classification-pane" role="tabpanel" aria-labelledby="instability-classification-tab" tabindex="0">
-                    <div class="instability-filter-card">
-                        <div class="instability-filter-card-title">
+                <section class="instability-filter-card">
+                    <button class="instability-filter-card-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#instability-classification-section" aria-controls="instability-classification-section" aria-expanded="{% if selected_inst_type_ids or selected_ra_check_ids or selected_excluded_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or selected_row_quality %}true{% else %}false{% endif %}">
+                        <span class="instability-filter-card-title">
                             <span class="small fw-bold text-dark">Classification</span>
-                            <span class="small text-secondary">Narrow by event type, review labels, intensity, or extent.</span>
-                        </div>
-                        <div class="row g-2">
-                            <div class="col-md-4 pb-2">
-                                <label for="inst_type_select" class="text-secondary d-block">Event Types</label>
-                                <select id="inst_type_select" name="inst_type" class="form-select js-instability-multiple" multiple data-placeholder="Search event types">
-                                  {% for type in instability_types %}
-                                    <option value="{{ type.id }}" {% if type.id|stringformat:"s" in selected_inst_type_ids %}selected{% endif %}>
-                                      {{ type.name }} - {{ type.event_count }}
-                                    </option>
-                                  {% endfor %}
-                                </select>
-                                <div class="instability-filter-help">Select one or more instability categories.</div>
-                            </div>
+                            <span class="small text-secondary">Event category, review labels, intensity, and extent.</span>
+                        </span>
+                        <span class="instability-filter-card-summary">
+                            {% if selected_inst_type_ids %}
+                                <span class="badge rounded-pill bg-info-light text-dark">{{ selected_inst_type_ids|length }} types</span>
+                            {% else %}
+                                <span>All types</span>
+                            {% endif %}
+                            {% if selected_ra_check_ids %}
+                                <span class="badge rounded-pill bg-violet-light text-dark">{{ selected_ra_check_ids|length }} required checks</span>
+                            {% endif %}
+                            {% if selected_row_quality %}
+                                <span class="badge rounded-pill bg-colorful text-dark">Invalid rows excluded</span>
+                            {% endif %}
+                            {% if selected_inst_intensity_values or selected_inst_extent_values %}
+                                <span class="badge rounded-pill bg-secondary-light text-dark">Severity filters active</span>
+                            {% endif %}
+                        </span>
+                        <i class="fa-solid fa-chevron-down instability-filter-card-chevron"></i>
+                    </button>
+                    <div id="instability-classification-section" class="collapse {% if selected_inst_type_ids or selected_ra_check_ids or selected_excluded_ra_check_ids or selected_inst_extent_values or selected_inst_intensity_values or selected_row_quality %}show{% endif %}">
+                        <div class="instability-filter-card-body">
+                            <div class="row g-2">
+                                <div class="col-md-4 pb-2 instability-filter-field">
+                                    <label for="inst_type_select" class="text-secondary d-block">Event Types</label>
+                                    <select id="inst_type_select" name="inst_type" class="form-select js-instability-multiple" multiple data-placeholder="Search event types">
+                                      {% for type in instability_types %}
+                                        <option value="{{ type.id }}" {% if type.id|stringformat:"s" in selected_inst_type_ids %}selected{% endif %}>
+                                          {{ type.name }} - {{ type.event_count }}
+                                        </option>
+                                      {% endfor %}
+                                    </select>
+                                    <div class="instability-filter-help">Select one or more instability categories.</div>
+                                </div>
 
-                            <div class="col-md-4 pb-2">
-                                <label for="ra_check_select" class="text-secondary d-block">Researcher Checks</label>
-                                <select id="ra_check_select" name="ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Search researcher checks">
-                                  {% for check in check_choices %}
-                                    <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_ra_check_ids %}selected{% endif %}>
-                                      {{ check.name }} - {{ check.event_count }}
-                                    </option>
-                                  {% endfor %}
-                                </select>
-                                <div class="instability-filter-help">Correction labels stay searchable; invalid labels can be excluded above.</div>
-                            </div>
+                                <div class="col-md-4 pb-2 instability-filter-field">
+                                    <label for="ra_check_select" class="text-secondary d-block">Require Researcher Checks</label>
+                                    <select id="ra_check_select" name="ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Search researcher checks">
+                                      {% for check in check_choices %}
+                                        <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_ra_check_ids %}selected{% endif %}>
+                                          {{ check.name }} - {{ check.event_count }}
+                                        </option>
+                                      {% endfor %}
+                                    </select>
+                                    <div class="instability-filter-help">Keep only rows that carry at least one selected review label.</div>
+                                </div>
 
-                            <div class="col-md-4 pb-2">
-                                <label for="excluded_ra_check_select" class="text-secondary d-block">Excluded Invalid Labels</label>
-                                <select id="excluded_ra_check_select" name="excluded_ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Default invalid labels" data-default-values="{{ default_excluded_ra_check_ids|join:',' }}">
-                                  {% for check in excluded_ra_check_choices %}
-                                    <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_excluded_ra_check_ids %}selected{% endif %}>
-                                      {{ check.name }} - {{ check.event_count }}
-                                    </option>
-                                  {% endfor %}
-                                </select>
-                                <div class="instability-filter-help">Used when Exclude invalid rows is active. Defaults can be removed or extended here.</div>
-                            </div>
+                                <div class="col-md-4 pb-2 instability-filter-field">
+                                    <label for="excluded_ra_check_select" class="text-secondary d-block">Exclude Researcher Checks</label>
+                                    <select id="excluded_ra_check_select" name="excluded_ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Default invalid labels" data-default-values="{{ default_excluded_ra_check_ids|join:',' }}">
+                                      {% for check in excluded_ra_check_choices %}
+                                        <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_excluded_ra_check_ids %}selected{% endif %}>
+                                          {{ check.name }} - {{ check.event_count }}
+                                        </option>
+                                      {% endfor %}
+                                    </select>
+                                    <div class="instability-filter-actions">
+                                        <button type="button" class="btn btn-outline-secondary" data-instability-excluded-action="default">Default invalid</button>
+                                        <button type="button" class="btn btn-outline-secondary" data-instability-excluded-action="all">Exclude all labels</button>
+                                        <button type="button" class="btn btn-outline-secondary" data-instability-excluded-action="clear">Exclude none</button>
+                                    </div>
+                                    <div class="instability-filter-help">This removes rows with selected labels. Exclude none clears this rule and includes labels again.</div>
+                                </div>
 
-                            <div class="col-md-4 pb-2">
-                                <label for="inst_intensity_select" class="text-secondary">Intensity</label>
-                                <select id="inst_intensity_select" name="inst_intensity" class="form-select js-instability-multiple" multiple data-placeholder="All intensities">
-                                  {% for val, label, count in inst_intensity_filter_choices %}
-                                    <option value="{{ val }}" {% if val in selected_inst_intensity_values %}selected{% endif %}>
-                                      {{ label }} - {{ count }}
-                                    </option>
-                                  {% endfor %}
-                                </select>
-                            </div>
+                                <div class="col-md-4 pb-2 instability-filter-field">
+                                    <label for="inst_intensity_select" class="text-secondary">Intensity</label>
+                                    <select id="inst_intensity_select" name="inst_intensity" class="form-select js-instability-multiple" multiple data-placeholder="All intensities">
+                                      {% for val, label, count in inst_intensity_filter_choices %}
+                                        <option value="{{ val }}" {% if val in selected_inst_intensity_values %}selected{% endif %}>
+                                          {{ label }} - {{ count }}
+                                        </option>
+                                      {% endfor %}
+                                    </select>
+                                </div>
 
-                            <div class="col-md-4 pb-2">
-                                <label for="inst_extent_select" class="text-secondary">Extent</label>
-                                <select id="inst_extent_select" name="inst_extent" class="form-select js-instability-multiple" multiple data-placeholder="All extents">
-                                  {% for val, label, count in inst_extent_filter_choices %}
-                                    <option value="{{ val }}" {% if val in selected_inst_extent_values %}selected{% endif %}>
-                                      {{ label }} - {{ count }}
-                                    </option>
-                                  {% endfor %}
-                                </select>
+                                <div class="col-md-4 pb-2 instability-filter-field">
+                                    <label for="inst_extent_select" class="text-secondary">Extent</label>
+                                    <select id="inst_extent_select" name="inst_extent" class="form-select js-instability-multiple" multiple data-placeholder="All extents">
+                                      {% for val, label, count in inst_extent_filter_choices %}
+                                        <option value="{{ val }}" {% if val in selected_inst_extent_values %}selected{% endif %}>
+                                          {{ label }} - {{ count }}
+                                        </option>
+                                      {% endfor %}
+                                    </select>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </section>
 
-                <div class="tab-pane fade" id="instability-time-pane" role="tabpanel" aria-labelledby="instability-time-tab" tabindex="0">
-                    <div class="instability-filter-card">
-                        <div class="instability-filter-card-title">
+                <section class="instability-filter-card">
+                    <button class="instability-filter-card-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#instability-time-section" aria-controls="instability-time-section" aria-expanded="{% if request.GET.year_from_min or request.GET.year_to_max %}true{% else %}false{% endif %}">
+                        <span class="instability-filter-card-title">
                             <span class="small fw-bold text-dark">Time</span>
                             <span class="small text-secondary">Constrain the effective year range.</span>
-                        </div>
-                        <div class="row g-2">
-                            <div class="col-md-2 pb-2">
-                                <label class="text-secondary" for="year_from_min">Start Year</label>
-                                <input type="number" name="year_from_min" id="year_from_min" class="form-control" value="{{ request.GET.year_from_min }}" placeholder="Min">
-                            </div>
+                        </span>
+                        <span class="instability-filter-card-summary">
+                            {% if request.GET.year_from_min %}
+                                <span class="badge rounded-pill bg-orange-light text-dark">From {{ request.GET.year_from_min }}</span>
+                            {% endif %}
+                            {% if request.GET.year_to_max %}
+                                <span class="badge rounded-pill bg-orange-light text-dark">To {{ request.GET.year_to_max }}</span>
+                            {% endif %}
+                            {% if not request.GET.year_from_min and not request.GET.year_to_max %}
+                                <span>All years</span>
+                            {% endif %}
+                        </span>
+                        <i class="fa-solid fa-chevron-down instability-filter-card-chevron"></i>
+                    </button>
+                    <div id="instability-time-section" class="collapse {% if request.GET.year_from_min or request.GET.year_to_max %}show{% endif %}">
+                        <div class="instability-filter-card-body">
+                            <div class="row g-2">
+                                <div class="col-md-2 pb-2 instability-filter-field">
+                                    <label class="text-secondary" for="year_from_min">Start Year</label>
+                                    <input type="number" name="year_from_min" id="year_from_min" class="form-control" value="{{ request.GET.year_from_min }}" placeholder="Min">
+                                </div>
 
-                            <div class="col-md-2 pb-2">
-                                <label class="text-secondary" for="year_to_max">End Year</label>
-                                <input type="number" name="year_to_max" id="year_to_max" class="form-control" value="{{ request.GET.year_to_max }}" placeholder="Max">
+                                <div class="col-md-2 pb-2 instability-filter-field">
+                                    <label class="text-secondary" for="year_to_max">End Year</label>
+                                    <input type="number" name="year_to_max" id="year_to_max" class="form-control" value="{{ request.GET.year_to_max }}" placeholder="Max">
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </section>
             </div>
         </div>
       </form>
@@ -679,6 +951,7 @@
     const $tokenFilter = jQuery(".js-instability-token-filter");
     const $filterPanel = jQuery(".instability-filter-panel");
     const $rowQuality = jQuery("#row_quality");
+    const $raCheckSelect = jQuery("#ra_check_select");
     const $excludedRaCheckSelect = jQuery("#excluded_ra_check_select");
 
     function escapeHtml(value) {
@@ -698,7 +971,7 @@
       const kindLabels = {
         event: "Event",
         inst_type: "Type",
-        is_macro_event: "Macro",
+        is_macro_event: "Macroevent",
         macro_event: "Umbrella",
         polity: "Polity",
         ra_check: "Check",
@@ -734,6 +1007,103 @@
       return defaultValues.split(",").filter(function (value) {
         return value;
       });
+    }
+
+    function getAllExcludedRaCheckIds() {
+      return $excludedRaCheckSelect.find("option").map(function () {
+        return this.value;
+      }).get().filter(function (value) {
+        return value;
+      });
+    }
+
+    function setExcludedRaChecks(values, rowQualityValue) {
+      $excludedRaCheckSelect.val(values).trigger("change");
+      $rowQuality.val(rowQualityValue).trigger("change");
+      removeRequiredRaCheckValues(values);
+      removeTokenValuesByKind("ra_check", values);
+    }
+
+    function getSelectedValues($select) {
+      return $select.val() || [];
+    }
+
+    function removeSelectValues($select, valuesToRemove) {
+      const removeValues = new Set((valuesToRemove || []).map(String));
+      if (!removeValues.size) {
+        return false;
+      }
+
+      const currentValues = getSelectedValues($select);
+      const nextValues = currentValues.filter(function (value) {
+        return !removeValues.has(String(value));
+      });
+
+      if (nextValues.length === currentValues.length) {
+        return false;
+      }
+
+      $select.val(nextValues).trigger("change");
+      return true;
+    }
+
+    function getTokenParts(tokenId) {
+      const tokenValue = String(tokenId || "");
+      const separatorIndex = tokenValue.indexOf(":");
+      if (separatorIndex === -1) {
+        return null;
+      }
+      return {
+        kind: tokenValue.slice(0, separatorIndex),
+        value: tokenValue.slice(separatorIndex + 1)
+      };
+    }
+
+    function getTokenValuesByKind(kind) {
+      return getSelectedValues($tokenFilter).map(getTokenParts).filter(function (token) {
+        return token && token.kind === kind;
+      }).map(function (token) {
+        return token.value;
+      });
+    }
+
+    function removeTokenValuesByKind(kind, valuesToRemove) {
+      const removeValues = new Set((valuesToRemove || []).map(String));
+      if (!removeValues.size) {
+        return false;
+      }
+
+      const currentTokens = getSelectedValues($tokenFilter);
+      const nextTokens = currentTokens.filter(function (tokenId) {
+        const token = getTokenParts(tokenId);
+        return !token || token.kind !== kind || !removeValues.has(String(token.value));
+      });
+
+      if (nextTokens.length === currentTokens.length) {
+        return false;
+      }
+
+      $tokenFilter.val(nextTokens).trigger("change");
+      return true;
+    }
+
+    function getRequiredRaCheckValues() {
+      const values = getSelectedValues($raCheckSelect).concat(getTokenValuesByKind("ra_check"));
+      return values.filter(function (value, index) {
+        return values.indexOf(value) === index;
+      });
+    }
+
+    function removeExcludedRaCheckValues(valuesToRemove) {
+      const removed = removeSelectValues($excludedRaCheckSelect, valuesToRemove);
+      if (removed && !getSelectedValues($excludedRaCheckSelect).length) {
+        $rowQuality.val("").trigger("change");
+      }
+      return removed;
+    }
+
+    function removeRequiredRaCheckValues(valuesToRemove) {
+      return removeSelectValues($raCheckSelect, valuesToRemove);
     }
 
     function populateDefaultExcludedRaChecks() {
@@ -804,6 +1174,41 @@
       }
     });
 
+    jQuery("[data-instability-excluded-action]").on("click", function () {
+      const action = jQuery(this).data("instability-excluded-action");
+      if (action === "default") {
+        setExcludedRaChecks(getDefaultExcludedRaCheckIds(), "good");
+      } else if (action === "all") {
+        setExcludedRaChecks(getAllExcludedRaCheckIds(), "good");
+      } else if (action === "clear") {
+        setExcludedRaChecks([], "");
+      }
+      cleanupInstabilityChoices();
+    });
+
+    $raCheckSelect.on("select2:select", function (event) {
+      const selectedValue = event.params && event.params.data && event.params.data.id;
+      removeExcludedRaCheckValues([selectedValue]);
+      cleanupInstabilityChoices();
+    });
+
+    $excludedRaCheckSelect.on("select2:select", function (event) {
+      const selectedValue = event.params && event.params.data && event.params.data.id;
+      removeRequiredRaCheckValues([selectedValue]);
+      removeTokenValuesByKind("ra_check", [selectedValue]);
+      if (getSelectedValues($excludedRaCheckSelect).length) {
+        $rowQuality.val("good").trigger("change");
+      }
+      cleanupInstabilityChoices();
+    });
+
+    $tokenFilter.on("select2:select", function (event) {
+      const selectedToken = event.params && event.params.data;
+      if (selectedToken && selectedToken.kind === "ra_check") {
+        removeExcludedRaCheckValues([selectedToken.value]);
+      }
+    });
+
     function tokenToParam(tokenId) {
       const separatorIndex = tokenId.indexOf(":");
       if (separatorIndex === -1) {
@@ -832,7 +1237,6 @@
 
     jQuery(".instability-filter-panel form").on("submit", function () {
       const $form = jQuery(this);
-      const excludedRaCheckValues = $excludedRaCheckSelect.val() || [];
       $form.find("[data-instability-token-param='true']").remove();
       $form.find("[data-instability-excluded-mode='true']").remove();
       ($tokenFilter.val() || []).forEach(function (tokenId) {
@@ -847,6 +1251,9 @@
           "data-instability-token-param": "true"
         }).appendTo($form);
       });
+
+      removeExcludedRaCheckValues(getRequiredRaCheckValues());
+      const excludedRaCheckValues = getSelectedValues($excludedRaCheckSelect);
 
       if ($rowQuality.val() !== "good" && excludedRaCheckValues.length) {
         $rowQuality.val("good");
@@ -873,8 +1280,11 @@
       clearSelect2SearchText(jQuery(this));
     });
     $instabilitySelects.add($tokenFilter).on("change select2:select select2:unselect select2:open", cleanupInstabilityChoices);
-    document.querySelectorAll('[data-bs-toggle="tab"]').forEach(function (tabButton) {
-      tabButton.addEventListener("shown.bs.tab", cleanupInstabilityChoices);
+    document.querySelectorAll(".instability-filter-panel .collapse").forEach(function (section) {
+      section.addEventListener("shown.bs.collapse", function () {
+        jQuery(section).find(".select2-container").css("width", "100%");
+        cleanupInstabilityChoices();
+      });
     });
     cleanupInstabilityChoices();
   });

--- a/seshat/apps/core/templates/core/partials/_instability_list_filters.html
+++ b/seshat/apps/core/templates/core/partials/_instability_list_filters.html
@@ -2,47 +2,184 @@
 
 <style>
   .instability-filter-panel {
+    --instability-ink: #2d2520;
+    --instability-muted: #70655f;
+    --instability-line: rgba(120, 40, 35, 0.14);
+    --instability-soft: rgba(120, 40, 35, 0.06);
+    --instability-teal: #0f766e;
+    --instability-teal-soft: rgba(15, 118, 110, 0.1);
+    --instability-rose: #782823;
     background:
-      linear-gradient(135deg, rgba(246, 127, 127, 0.08), rgba(242, 199, 119, 0.12), rgba(151, 230, 151, 0.1)),
+      radial-gradient(circle at 12% 0%, rgba(244, 183, 112, 0.22), transparent 26rem),
+      radial-gradient(circle at 88% 6%, rgba(116, 199, 179, 0.18), transparent 24rem),
+      linear-gradient(180deg, #fffdf7 0%, #fff8ed 100%),
       #fffdf2;
+    border-color: rgba(87, 82, 74, 0.55) !important;
+    border-radius: 16px !important;
+    box-shadow: 0 16px 40px rgba(89, 54, 32, 0.08);
+    overflow: visible;
+    position: relative;
+  }
+
+  .instability-filter-heading {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+  }
+
+  .instability-filter-heading strong {
+    color: var(--instability-ink);
+    font-size: 1.04rem;
+  }
+
+  .instability-filter-subtitle {
+    color: var(--instability-muted);
+    font-size: 0.9rem;
+    margin-top: 0.15rem;
   }
 
   .instability-filter-summary {
     position: sticky;
     top: 55px;
     z-index: 920;
-    background: rgba(255, 253, 242, 0.95);
-    border: 1px solid rgba(120, 40, 35, 0.14);
-    border-radius: 12px;
-    box-shadow: 0 8px 20px rgba(120, 40, 35, 0.08);
+    background: rgba(255, 253, 248, 0.94);
+    border: 1px solid var(--instability-line);
+    border-radius: 18px;
+    box-shadow: 0 18px 34px rgba(89, 54, 32, 0.11);
+    padding: 0.9rem;
+    backdrop-filter: blur(10px);
+  }
+
+  .instability-summary-main {
+    display: grid;
+    grid-template-columns: minmax(18rem, 1fr) auto;
+    gap: 0.85rem;
+    align-items: end;
+  }
+
+  .instability-global-filter {
+    min-width: 0;
+  }
+
+  .instability-global-filter label,
+  .instability-quick-row-label {
+    display: block;
+    color: var(--instability-muted);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.35rem;
+    text-transform: uppercase;
+  }
+
+  .instability-summary-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    justify-content: flex-end;
+  }
+
+  .instability-summary-actions .btn,
+  .instability-quick-row .btn {
+    border-radius: 999px;
+  }
+
+  .instability-summary-actions .btn[type="submit"] {
+    border: 1px solid rgba(15, 118, 110, 0.3);
+    box-shadow: 0 8px 18px rgba(15, 118, 110, 0.12);
+    color: #5a211d;
+  }
+
+  .instability-quick-row {
+    align-items: center;
+    border-top: 1px dashed var(--instability-line);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 0.8rem;
+    padding-top: 0.75rem;
+  }
+
+  .instability-active-filters {
+    background: rgba(255, 255, 255, 0.58);
+    border: 1px solid var(--instability-line);
+    border-radius: 14px;
+    margin-top: 0.75rem;
     padding: 0.65rem;
   }
 
+  .instability-active-filter-label {
+    color: var(--instability-muted);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.45rem;
+    text-transform: uppercase;
+  }
+
+  .instability-active-filter-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .instability-active-filter-list .list-inline-item {
+    align-items: center;
+    background: rgba(255, 253, 250, 0.9) !important;
+    border: 1px solid rgba(120, 40, 35, 0.12);
+    border-radius: 999px !important;
+    box-shadow: 0 5px 14px rgba(89, 54, 32, 0.06);
+    display: inline-flex;
+    gap: 0.2rem;
+    margin: 0 !important;
+    padding: 0.34rem 0.5rem 0.34rem 0.62rem !important;
+  }
+
+  .instability-active-filter-list .list-inline-item a {
+    align-items: center;
+    border-radius: 999px;
+    color: var(--instability-rose) !important;
+    display: inline-flex;
+    justify-content: center;
+    line-height: 1;
+    margin-left: 0.2rem !important;
+    min-height: 1.1rem;
+    min-width: 1.1rem;
+    text-decoration: none;
+  }
+
+  .instability-active-filter-list .list-inline-item a:hover {
+    background: rgba(120, 40, 35, 0.09);
+  }
+
   .instability-filter-tabs {
-    border-bottom-color: rgba(120, 40, 35, 0.18);
+    border-bottom: 0;
+    gap: 0.35rem;
   }
 
   .instability-filter-tabs .nav-link {
-    color: #5f6b76;
+    color: var(--instability-muted);
+    background: rgba(255, 255, 255, 0.45);
     border: 1px solid transparent;
-    border-top-left-radius: 10px;
-    border-top-right-radius: 10px;
+    border-radius: 999px;
     font-weight: 700;
-    padding: 0.45rem 0.8rem;
+    padding: 0.5rem 0.9rem;
   }
 
   .instability-filter-tabs .nav-link.active {
-    color: #212529;
-    background: rgba(255, 255, 255, 0.86);
-    border-color: rgba(120, 40, 35, 0.18) rgba(120, 40, 35, 0.18) rgba(255, 255, 255, 0.86);
+    color: var(--instability-ink);
+    background: #fffdfa;
+    border-color: var(--instability-line);
+    box-shadow: 0 8px 20px rgba(89, 54, 32, 0.08);
   }
 
   .instability-filter-card {
-    background: rgba(255, 255, 255, 0.72);
-    border: 1px solid rgba(120, 40, 35, 0.14);
-    border-top: 0;
-    border-radius: 0 0 12px 12px;
-    padding: 0.75rem;
+    background: rgba(255, 253, 250, 0.82);
+    border: 1px solid var(--instability-line);
+    border-radius: 16px;
+    margin-top: 0.55rem;
+    padding: 0.85rem;
   }
 
   .instability-filter-card-title {
@@ -51,7 +188,7 @@
     align-items: baseline;
     justify-content: space-between;
     gap: 0.5rem;
-    border-bottom: 1px solid rgba(120, 40, 35, 0.12);
+    border-bottom: 1px solid rgba(120, 40, 35, 0.1);
     padding-bottom: 0.35rem;
     margin-bottom: 0.6rem;
   }
@@ -63,26 +200,6 @@
     margin-top: 0.25rem;
   }
 
-  .instability-quick-row {
-    background: rgba(255, 255, 255, 0.42);
-    border-radius: 10px;
-    padding: 0.35rem;
-  }
-
-  .instability-summary-search {
-    flex: 1 1 18rem;
-    min-width: min(100%, 18rem);
-  }
-
-  .instability-summary-batch {
-    flex: 1 1 18rem;
-    min-width: min(100%, 18rem);
-  }
-
-  .instability-summary-actions {
-    flex: 0 0 auto;
-  }
-
   .instability-filter-panel .select2-container {
     width: 100% !important;
   }
@@ -92,6 +209,18 @@
     max-height: 118px;
     overflow-y: auto;
     padding: 4px 6px;
+    border-color: rgba(120, 40, 35, 0.16);
+    border-radius: 12px;
+    background: #fff;
+  }
+
+  .instability-global-filter .select2-container--default .select2-selection--multiple {
+    min-height: 58px;
+    max-height: 140px;
+    padding: 8px 10px;
+    border: 1px solid rgba(120, 40, 35, 0.2);
+    border-radius: 16px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__rendered {
@@ -106,10 +235,11 @@
     display: inline-block;
     max-width: 100%;
     margin: 0;
-    padding: 2px 1.75rem 2px 8px;
-    border-color: rgba(25, 135, 84, 0.75);
-    background: rgba(151, 230, 151, 0.45);
-    color: #123f18;
+    padding: 0.28rem 1.75rem 0.28rem 0.62rem;
+    border-color: rgba(15, 118, 110, 0.26);
+    border-radius: 999px;
+    background: var(--instability-teal-soft);
+    color: #10433e;
     white-space: normal;
   }
 
@@ -128,7 +258,7 @@
     padding: 0;
     border: 0;
     border-radius: 999px;
-    color: #0f5132;
+    color: #0f5e56;
     float: none;
     font-weight: 700;
     line-height: 1;
@@ -137,8 +267,8 @@
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
-    background: rgba(15, 81, 50, 0.14);
-    color: #842029;
+    background: rgba(15, 118, 110, 0.14);
+    color: var(--instability-rose);
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__clear {
@@ -148,11 +278,131 @@
   .instability-filter-panel .select2-container--default .select2-search--inline .select2-search__field {
     min-width: 16rem;
     margin-top: 3px;
+    color: var(--instability-ink);
   }
 
   .instability-filter-panel .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
     color: #6c757d;
     margin-top: 3px;
+  }
+
+  .instability-filter-panel .select2-dropdown,
+  .instability-filter-dropdown {
+    overflow: hidden;
+    border: 1px solid var(--instability-line, rgba(120, 40, 35, 0.14)) !important;
+    border-radius: 16px !important;
+    background: #fffdfa !important;
+    box-shadow: 0 18px 34px rgba(89, 54, 32, 0.18) !important;
+  }
+
+  .instability-filter-panel .select2-results,
+  .instability-filter-dropdown .select2-results {
+    background: #fffdfa !important;
+  }
+
+  .instability-filter-panel .select2-results__options,
+  .instability-filter-dropdown .select2-results__options {
+    max-height: 360px !important;
+    background: #fffdfa !important;
+  }
+
+  .instability-filter-panel .select2-results__options--nested,
+  .instability-filter-dropdown .select2-results__options--nested {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  .instability-filter-panel .select2-results__group,
+  .instability-filter-dropdown .select2-results__group {
+    background: #fffdfa !important;
+    padding: 0.72rem 0.9rem 0.35rem;
+    color: var(--instability-muted, #70655f) !important;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .instability-filter-panel .select2-results__option,
+  .instability-filter-dropdown .select2-results__option {
+    background: #fffdfa !important;
+    color: var(--instability-ink, #2d2520) !important;
+    display: block !important;
+    float: none !important;
+    padding: 0.62rem 0.9rem;
+  }
+
+  .instability-filter-panel .select2-results__option[role="group"],
+  .instability-filter-dropdown .select2-results__option[role="group"] {
+    background: #fffdfa !important;
+    padding: 0 !important;
+  }
+
+  .instability-filter-panel .select2-results__option--highlighted[aria-selected],
+  .instability-filter-panel .select2-results__option--highlighted.select2-results__option--selectable,
+  .instability-filter-panel .select2-results__option--selectable:hover,
+  .instability-filter-dropdown .select2-results__option--highlighted[aria-selected],
+  .instability-filter-dropdown .select2-results__option--highlighted.select2-results__option--selectable,
+  .instability-filter-dropdown .select2-results__option--selectable:hover {
+    background: rgba(15, 118, 110, 0.12) !important;
+    color: var(--instability-ink, #2d2520) !important;
+  }
+
+  .instability-filter-panel .select2-results__option[aria-selected="true"]:not(.select2-results__option--highlighted),
+  .instability-filter-dropdown .select2-results__option[aria-selected="true"]:not(.select2-results__option--highlighted) {
+    background: rgba(120, 40, 35, 0.06) !important;
+    color: var(--instability-ink, #2d2520) !important;
+  }
+
+  .instability-token-result {
+    clear: both;
+    display: grid;
+    grid-template-columns: minmax(5.5rem, 7rem) minmax(0, 1fr);
+    gap: 0.65rem;
+    align-items: start;
+    min-height: 2.4rem;
+    width: 100%;
+  }
+
+  .instability-token-kind {
+    color: var(--instability-teal);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    line-height: 1.25;
+    padding-top: 0.18rem;
+    text-transform: uppercase;
+  }
+
+  .instability-token-result-main {
+    display: block;
+    font-weight: 700;
+    line-height: 1.25;
+    min-width: 0;
+  }
+
+  .instability-token-result-meta {
+    display: block;
+    color: var(--instability-muted);
+    font-size: 0.8rem;
+    line-height: 1.3;
+    margin-top: 0.12rem;
+    min-width: 0;
+  }
+
+  .instability-token-result-content {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  @media (max-width: 991px) {
+    .instability-summary-main {
+      grid-template-columns: 1fr;
+    }
+
+    .instability-summary-actions {
+      justify-content: flex-start;
+    }
   }
 </style>
 
@@ -160,7 +410,7 @@
     <form method="get" class="row g-2 mb-3">
         <div class="col-12 d-flex flex-wrap justify-content-between align-items-center gap-2 pb-1">
             <div>
-                <div class="d-flex flex-wrap align-items-center gap-2">
+                <div class="instability-filter-heading">
                     <strong class="text-dark">Filter Instability Events</strong>
                     <span class="badge rounded-pill bg-colorful border text-dark">
                         {% if record_count is not None %}
@@ -175,7 +425,7 @@
                         <span class="badge rounded-pill bg-absent-light text-secondary">No filters active</span>
                     {% endif %}
                 </div>
-                <div class="small text-secondary">
+                <div class="instability-filter-subtitle">
                     Build a research set by combining scope, source, quality, classification, and time filters.
                 </div>
             </div>
@@ -183,44 +433,15 @@
 
         <div class="col-12">
             <div class="instability-filter-summary">
-                <div class="d-flex flex-wrap justify-content-between align-items-end gap-2">
-                    <div class="d-flex flex-wrap align-items-center gap-2 instability-quick-row">
-                        <span class="small fw-semibold text-secondary me-1">Common views</span>
-                        <a href="?{% query_transform request row_quality='good' %}" class="btn btn-sm {% if selected_row_quality == 'good' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
-                            Exclude invalid rows
-                        </a>
-                        {% if selected_row_quality == 'good' %}
-                            <a href="?{% query_transform request row_quality=None %}" class="btn btn-sm btn-outline-secondary">Include invalid rows</a>
-                        {% endif %}
-                        <a href="?{% query_transform request source='llm' %}" class="btn btn-sm {% if selected_source == 'llm' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
-                            Only LLM
-                        </a>
-                        <a href="?{% query_transform request source='manual' selected_batch=None %}" class="btn btn-sm {% if selected_source == 'manual' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
-                            Only manual
-                        </a>
-                        {% if selected_source_values %}
-                            <a href="?{% query_transform request source=None selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All sources</a>
-                        {% endif %}
-                        {% if selected_batch_values %}
-                            <a href="?{% query_transform request selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All batches</a>
-                        {% endif %}
-                    </div>
-
-                    <div class="instability-summary-search">
-                        <label for="searched_name" class="small fw-semibold text-secondary mb-1">Search events</label>
-                        <input type="text" name="searched_name" id="searched_name" class="form-control form-control-sm" value="{{ name_query }}" placeholder="Search event names">
-                    </div>
-
-                    <div class="instability-summary-batch">
-                        <label for="selected_batch" class="small fw-semibold text-secondary mb-1">LLM batches</label>
-                        <select name="selected_batch" id="selected_batch" class="form-select js-instability-multiple" multiple data-placeholder="All LLM batches">
-                          {% for batch, count in batch_filter_choices %}
-                            <option value="{{ batch }}" {% if batch in selected_batch_values %}selected{% endif %}>
-                              {{ batch }} - {{ count }}
-                            </option>
+                <div class="instability-summary-main">
+                    <div class="instability-global-filter">
+                        <label for="global_filter_tokens" class="small fw-semibold text-secondary mb-1">Search & add filters</label>
+                        <select id="global_filter_tokens" class="form-select js-instability-token-filter" multiple data-ajax-url="{% url 'instability_event-filter-tokens' %}" data-placeholder="Search events, polities, batches, sources, types, checks, or macroevent state">
+                          {% for token in selected_global_filter_tokens %}
+                            <option value="{{ token.token_id }}" selected>{{ token.label }}</option>
                           {% endfor %}
                         </select>
-                        <div class="instability-filter-help mb-0">Batch filters always limit results to LLM rows.</div>
+                        <div class="instability-filter-help mb-0">Type to preview matching filter tokens. Selected tokens become normal filters when you apply.</div>
                     </div>
 
                     <div class="d-flex flex-wrap align-items-center gap-2 instability-summary-actions">
@@ -229,6 +450,28 @@
                         </button>
                         <a href="?" class="btn btn-outline-danger btn-sm fw-semibold text-nowrap">Clear All</a>
                     </div>
+                </div>
+
+                <div class="instability-quick-row">
+                    <span class="instability-quick-row-label mb-0 me-1">Common views</span>
+                    <a href="?{% query_transform request row_quality='good' excluded_ra_check=None excluded_ra_check_mode=None %}" class="btn btn-sm {% if selected_row_quality == 'good' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                        Exclude invalid rows
+                    </a>
+                    {% if selected_row_quality == 'good' %}
+                        <a href="?{% query_transform request row_quality=None excluded_ra_check=None excluded_ra_check_mode=None %}" class="btn btn-sm btn-outline-secondary">Include invalid rows</a>
+                    {% endif %}
+                    <a href="?{% query_transform request source='llm' %}" class="btn btn-sm {% if selected_source == 'llm' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                        Only LLM
+                    </a>
+                    <a href="?{% query_transform request source='manual' selected_batch=None %}" class="btn btn-sm {% if selected_source == 'manual' %}btn-dark{% else %}btn-outline-secondary{% endif %}">
+                        Only manual
+                    </a>
+                    {% if selected_source_values %}
+                        <a href="?{% query_transform request source=None selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All sources</a>
+                    {% endif %}
+                    {% if selected_batch_values %}
+                        <a href="?{% query_transform request selected_batch=None %}" class="btn btn-sm btn-outline-secondary">All batches</a>
+                    {% endif %}
                 </div>
 
                 {% include "core/partials/_instability_active_filter_chips.html" %}
@@ -317,7 +560,7 @@
                                   <option value="">Include all rows</option>
                                   <option value="good" {% if selected_row_quality == "good" %}selected{% endif %}>Exclude invalid rows</option>
                                 </select>
-                                <div class="instability-filter-help">Invalid means Bad Row, Duplicate, Not Instability Event, or External Event.</div>
+                                <div class="instability-filter-help">Default invalid labels are configurable in the Classification tab.</div>
                             </div>
 
                             <div class="col-md-4 pb-2">
@@ -363,6 +606,18 @@
                                   {% endfor %}
                                 </select>
                                 <div class="instability-filter-help">Correction labels stay searchable; invalid labels can be excluded above.</div>
+                            </div>
+
+                            <div class="col-md-4 pb-2">
+                                <label for="excluded_ra_check_select" class="text-secondary d-block">Excluded Invalid Labels</label>
+                                <select id="excluded_ra_check_select" name="excluded_ra_check" class="form-select js-instability-multiple" multiple data-placeholder="Default invalid labels" data-default-values="{{ default_excluded_ra_check_ids|join:',' }}">
+                                  {% for check in excluded_ra_check_choices %}
+                                    <option value="{{ check.id }}" {% if check.id|stringformat:"s" in selected_excluded_ra_check_ids %}selected{% endif %}>
+                                      {{ check.name }} - {{ check.event_count }}
+                                    </option>
+                                  {% endfor %}
+                                </select>
+                                <div class="instability-filter-help">Used when Exclude invalid rows is active. Defaults can be removed or extended here.</div>
                             </div>
 
                             <div class="col-md-4 pb-2">
@@ -421,15 +676,192 @@
     }
 
     const $instabilitySelects = jQuery(".js-instability-multiple");
+    const $tokenFilter = jQuery(".js-instability-token-filter");
+    const $filterPanel = jQuery(".instability-filter-panel");
+    const $rowQuality = jQuery("#row_quality");
+    const $excludedRaCheckSelect = jQuery("#excluded_ra_check_select");
+
+    function escapeHtml(value) {
+      const htmlCharacters = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "\"": "&quot;",
+        "'": "&#39;"
+      };
+      return String(value || "").replace(/[&<>"']/g, function (character) {
+        return htmlCharacters[character];
+      });
+    }
+
+    function getTokenKindLabel(kind) {
+      const kindLabels = {
+        event: "Event",
+        inst_type: "Type",
+        is_macro_event: "Macro",
+        macro_event: "Umbrella",
+        polity: "Polity",
+        ra_check: "Check",
+        selected_batch: "Batch",
+        source: "Source",
+        text: "Text"
+      };
+      return kindLabels[kind] || "Filter";
+    }
+
+    function formatTokenResult(option) {
+      if (option.loading || !option.id) {
+        return escapeHtml(option.text);
+      }
+
+      const metadata = option.meta
+        ? '<span class="instability-token-result-meta">' + escapeHtml(option.meta) + "</span>"
+        : "";
+
+      return (
+        '<span class="instability-token-result">' +
+          '<span class="instability-token-kind">' + escapeHtml(getTokenKindLabel(option.kind)) + "</span>" +
+          '<span class="instability-token-result-content">' +
+            '<span class="instability-token-result-main">' + escapeHtml(option.text) + "</span>" +
+            metadata +
+          "</span>" +
+        "</span>"
+      );
+    }
+
+    function getDefaultExcludedRaCheckIds() {
+      const defaultValues = String($excludedRaCheckSelect.data("default-values") || "");
+      return defaultValues.split(",").filter(function (value) {
+        return value;
+      });
+    }
+
+    function populateDefaultExcludedRaChecks() {
+      if (!$excludedRaCheckSelect.length || ($excludedRaCheckSelect.val() || []).length) {
+        return;
+      }
+      const defaultValues = getDefaultExcludedRaCheckIds();
+      if (defaultValues.length) {
+        $excludedRaCheckSelect.val(defaultValues).trigger("change");
+      }
+    }
+
+    function clearSelect2SearchText($select) {
+      window.setTimeout(function () {
+        const select2 = $select.data("select2");
+        const $containerSearch = $select.next(".select2-container").find(".select2-search__field");
+        $containerSearch.val("").trigger("input");
+
+        if (select2 && select2.selection && select2.selection.$search) {
+          select2.selection.$search.val("").trigger("input");
+        }
+        if (select2 && select2.dropdown && select2.dropdown.$search) {
+          select2.dropdown.$search.val("").trigger("input");
+        }
+      }, 0);
+    }
 
     $instabilitySelects.each(function () {
       const $select = jQuery(this);
       $select.select2({
         allowClear: false,
         closeOnSelect: false,
+        dropdownCssClass: "instability-filter-dropdown",
+        dropdownParent: $filterPanel,
         placeholder: $select.data("placeholder") || "Search and select",
         width: "100%"
       });
+    });
+
+    $tokenFilter.select2({
+      ajax: {
+        data: function (params) {
+          return { q: params.term || "" };
+        },
+        dataType: "json",
+        delay: 250,
+        processResults: function (data) {
+          return data;
+        },
+        url: $tokenFilter.data("ajax-url")
+      },
+      allowClear: false,
+      closeOnSelect: false,
+      dropdownCssClass: "instability-filter-dropdown",
+      dropdownParent: $filterPanel,
+      escapeMarkup: function (markup) {
+        return markup;
+      },
+      minimumInputLength: 2,
+      placeholder: $tokenFilter.data("placeholder") || "Search and add filters",
+      templateResult: formatTokenResult,
+      width: "100%"
+    });
+
+    $rowQuality.on("change", function () {
+      if ($rowQuality.val() === "good") {
+        populateDefaultExcludedRaChecks();
+      }
+    });
+
+    function tokenToParam(tokenId) {
+      const separatorIndex = tokenId.indexOf(":");
+      if (separatorIndex === -1) {
+        return null;
+      }
+
+      const kind = tokenId.slice(0, separatorIndex);
+      const value = tokenId.slice(separatorIndex + 1);
+      const tokenParamMap = {
+        event: "event",
+        inst_type: "inst_type",
+        is_macro_event: "is_macro_event",
+        macro_event: "macro_event",
+        polity: "polity",
+        ra_check: "ra_check",
+        selected_batch: "selected_batch",
+        source: "source",
+        text: "q"
+      };
+
+      if (!tokenParamMap[kind] || !value) {
+        return null;
+      }
+      return { name: tokenParamMap[kind], value: value };
+    }
+
+    jQuery(".instability-filter-panel form").on("submit", function () {
+      const $form = jQuery(this);
+      const excludedRaCheckValues = $excludedRaCheckSelect.val() || [];
+      $form.find("[data-instability-token-param='true']").remove();
+      $form.find("[data-instability-excluded-mode='true']").remove();
+      ($tokenFilter.val() || []).forEach(function (tokenId) {
+        const param = tokenToParam(tokenId);
+        if (!param) {
+          return;
+        }
+        jQuery("<input>", {
+          type: "hidden",
+          name: param.name,
+          value: param.value,
+          "data-instability-token-param": "true"
+        }).appendTo($form);
+      });
+
+      if ($rowQuality.val() !== "good" && excludedRaCheckValues.length) {
+        $rowQuality.val("good");
+      }
+
+      if ($rowQuality.val() === "good") {
+        jQuery("<input>", {
+          type: "hidden",
+          name: "excluded_ra_check_mode",
+          value: "custom",
+          "data-instability-excluded-mode": "true"
+        }).appendTo($form);
+      } else {
+        $excludedRaCheckSelect.prop("disabled", true);
+      }
     });
 
     function cleanupInstabilityChoices() {
@@ -437,7 +869,10 @@
       jQuery(".instability-filter-panel .select2-selection__clear").remove();
     }
 
-    $instabilitySelects.on("change select2:select select2:unselect select2:open", cleanupInstabilityChoices);
+    $instabilitySelects.add($tokenFilter).on("select2:select", function () {
+      clearSelect2SearchText(jQuery(this));
+    });
+    $instabilitySelects.add($tokenFilter).on("change select2:select select2:unselect select2:open", cleanupInstabilityChoices);
     document.querySelectorAll('[data-bs-toggle="tab"]').forEach(function (tabButton) {
       tabButton.addEventListener("shown.bs.tab", cleanupInstabilityChoices);
     });

--- a/seshat/apps/crisisdb/instability_filters.py
+++ b/seshat/apps/crisisdb/instability_filters.py
@@ -6,6 +6,7 @@ from django.db.models.functions import Cast, Coalesce
 from django.utils.dateparse import parse_date
 from django.utils import timezone
 
+from ..core.filter_tokens import FilterTokenOption, build_grouped_token_response
 from ..core.models import Polity
 from .models import (
     Check_choice,
@@ -13,6 +14,7 @@ from .models import (
     INST_INTENSITY_CHOICES,
     Instability_event,
     Instability_type,
+    extract_macro_event_from_llm_name,
 )
 
 
@@ -23,14 +25,15 @@ BATCH_1_END_DATETIME = timezone.make_aware(datetime.datetime.combine(BATCH_1_END
 BATCH_2_END_DATETIME = timezone.make_aware(datetime.datetime.combine(BATCH_2_END, datetime.time()))
 BATCH_3_END_DATETIME = timezone.make_aware(datetime.datetime.combine(BATCH_3_END, datetime.time()))
 GOOD_ROW_FILTER = "good"
-GOOD_ROW_EXCLUDED_CHECK_NAMES = frozenset(
-    {
-        "Bad Row",
-        "Duplicate",
-        "Not Instability Event",
-        "External Event",
-    }
+GOOD_ROW_EXCLUDED_CHECK_NAMES = (
+    "Bad Row",
+    "Duplicate",
+    "Not Instability Event",
+    "External Event",
 )
+EXCLUDED_RA_CHECK_PARAM = "excluded_ra_check"
+EXCLUDED_RA_CHECK_MODE_PARAM = "excluded_ra_check_mode"
+CUSTOM_EXCLUDED_RA_CHECK_MODE = "custom"
 VALID_INSTABILITY_SOURCES = (
     Instability_event.Source.LLM,
     Instability_event.Source.MANUAL,
@@ -41,6 +44,7 @@ VALID_INSTABILITY_BATCHES = (
     "Batch 3",
     "Batch 4",
 )
+INSTABILITY_FILTER_TOKEN_LIMIT = 8
 
 
 def get_batch_tag(created_date):
@@ -98,6 +102,11 @@ def apply_instability_batch_filter(queryset, selected_batches):
     if not selected_batches:
         return queryset
 
+    return queryset.filter(build_instability_batch_query(selected_batches))
+
+
+def build_instability_batch_query(selected_batches):
+    selected_batches = normalize_instability_batches(selected_batches)
     batch_query = Q()
     if "Batch 1" in selected_batches:
         batch_query |= Q(created_date__lt=BATCH_1_END_DATETIME)
@@ -113,18 +122,61 @@ def apply_instability_batch_filter(queryset, selected_batches):
         )
     if "Batch 4" in selected_batches:
         batch_query |= Q(created_date__gte=BATCH_3_END_DATETIME)
-    return queryset.filter(batch_query)
+    return batch_query
 
 
 def get_request_list(request, key):
-    return [value.strip() for value in request.GET.getlist(key) if value and value.strip()]
+    values = []
+    for value in request.GET.getlist(key):
+        cleaned_value = value.strip() if value else ""
+        if cleaned_value and cleaned_value not in values:
+            values.append(cleaned_value)
+    return values
 
 
 def get_selected_row_quality(request):
     selected_row_quality = request.GET.get("row_quality")
     if selected_row_quality == GOOD_ROW_FILTER:
         return selected_row_quality
+    if any(value.strip() for value in request.GET.getlist(EXCLUDED_RA_CHECK_PARAM)):
+        return GOOD_ROW_FILTER
     return None
+
+
+def get_default_excluded_ra_check_ids():
+    return [
+        str(check_id)
+        for check_id in Check_choice.objects.filter(
+            name__in=GOOD_ROW_EXCLUDED_CHECK_NAMES
+        )
+        .order_by("name")
+        .values_list("id", flat=True)
+    ]
+
+
+def uses_custom_excluded_ra_checks(request):
+    return (
+        request.GET.get(EXCLUDED_RA_CHECK_MODE_PARAM) == CUSTOM_EXCLUDED_RA_CHECK_MODE
+        or bool(get_custom_excluded_ra_check_ids(request))
+    )
+
+
+def get_custom_excluded_ra_check_ids(request):
+    return [
+        value
+        for value in get_request_list(request, EXCLUDED_RA_CHECK_PARAM)
+        if value.isdigit()
+    ]
+
+
+def get_selected_excluded_ra_check_ids(request):
+    if get_selected_row_quality(request) != GOOD_ROW_FILTER:
+        return []
+
+    if uses_custom_excluded_ra_checks(request):
+        return get_custom_excluded_ra_check_ids(request)
+
+    return get_default_excluded_ra_check_ids()
 
 
 def build_macro_event_filter_query(selected_macro_events):
@@ -137,11 +189,19 @@ def build_macro_event_filter_query(selected_macro_events):
     return macro_event_query
 
 
-def apply_instability_row_quality_filter(queryset, selected_row_quality):
+def apply_instability_row_quality_filter(
+    queryset,
+    selected_row_quality,
+    excluded_ra_check_ids=None,
+    use_custom_excluded_ra_checks=False,
+):
     if selected_row_quality == GOOD_ROW_FILTER:
-        return queryset.exclude(
-            ra_check__name__in=GOOD_ROW_EXCLUDED_CHECK_NAMES
-        ).distinct()
+        if use_custom_excluded_ra_checks:
+            if not excluded_ra_check_ids:
+                return queryset
+            return queryset.exclude(ra_check__id__in=excluded_ra_check_ids).distinct()
+
+        return queryset.exclude(ra_check__name__in=GOOD_ROW_EXCLUDED_CHECK_NAMES).distinct()
     return queryset
 
 
@@ -180,6 +240,18 @@ def get_selected_instability_batches(request):
     return normalize_instability_batches(get_request_list(request, "selected_batch"))
 
 
+def get_selected_instability_event_ids(request):
+    return [
+        value
+        for value in get_request_list(request, "event")
+        if value.isdigit()
+    ]
+
+
+def get_selected_instability_text_queries(request):
+    return get_request_list(request, "q")
+
+
 def get_active_instability_filter_count(request):
     multi_value_filters = (
         "polity",
@@ -188,6 +260,8 @@ def get_active_instability_filter_count(request):
         "ra_check",
         "inst_extent",
         "inst_intensity",
+        "event",
+        "q",
     )
     active_count = sum(
         len(get_request_list(request, filter_name))
@@ -222,6 +296,59 @@ def apply_instability_event_source_filter(queryset, request):
     return queryset
 
 
+def build_instability_global_text_query(text_values):
+    global_query = Q()
+    for text_value in text_values:
+        item_query = (
+            Q(name__icontains=text_value)
+            | Q(llm_name__icontains=text_value)
+            | Q(polity__name__icontains=text_value)
+            | Q(polity__long_name__icontains=text_value)
+            | Q(polity__new_name__icontains=text_value)
+            | Q(inst_type__name__icontains=text_value)
+            | Q(ra_check__name__icontains=text_value)
+        )
+
+        matching_sources = [
+            source
+            for source, label in (
+                (Instability_event.Source.LLM, "LLM"),
+                (Instability_event.Source.MANUAL, "Manual"),
+            )
+            if _token_query_matches(text_value, source, label)
+        ]
+        if matching_sources:
+            item_query |= Q(source__in=matching_sources)
+
+        matching_batches = [
+            batch
+            for batch in VALID_INSTABILITY_BATCHES
+            if _token_query_matches(text_value, batch, batch.replace(" ", ""))
+        ]
+        if matching_batches:
+            item_query |= (
+                Q(source=Instability_event.Source.LLM)
+                & build_instability_batch_query(matching_batches)
+            )
+
+        for value, label in INST_INTENSITY_CHOICES:
+            if _token_query_matches(text_value, value, label):
+                item_query |= Q(inst_intensity=value)
+
+        for value, label in INST_EXTENT_CHOICES:
+            if _token_query_matches(text_value, value, label):
+                item_query |= Q(inst_extent=value)
+
+        global_query |= item_query
+    return global_query
+
+
+def apply_instability_global_text_filter(queryset, text_values):
+    if not text_values:
+        return queryset
+    return queryset.filter(build_instability_global_text_query(text_values)).distinct()
+
+
 def apply_instability_event_filters(queryset, request, ignored_filters=None):
     ignored_filters = set(ignored_filters or [])
     year_from_min = (
@@ -240,6 +367,12 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
     )
     selected_sources = (
         [] if "source" in ignored_filters else get_selected_instability_sources(request)
+    )
+    selected_event_ids = (
+        [] if "event" in ignored_filters else get_selected_instability_event_ids(request)
+    )
+    selected_text_queries = (
+        [] if "q" in ignored_filters else get_selected_instability_text_queries(request)
     )
     polity_ids = [] if "polity" in ignored_filters else get_request_list(request, "polity")
     inst_type_ids = (
@@ -274,6 +407,16 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
     selected_row_quality = (
         None if "row_quality" in ignored_filters else get_selected_row_quality(request)
     )
+    excluded_ra_check_ids = (
+        []
+        if EXCLUDED_RA_CHECK_PARAM in ignored_filters or "row_quality" in ignored_filters
+        else get_selected_excluded_ra_check_ids(request)
+    )
+    use_custom_excluded_ra_checks = (
+        False
+        if EXCLUDED_RA_CHECK_MODE_PARAM in ignored_filters or "row_quality" in ignored_filters
+        else uses_custom_excluded_ra_checks(request)
+    )
 
     if inst_type_ids:
         queryset = queryset.filter(inst_type__in=inst_type_ids).distinct()
@@ -290,6 +433,9 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
     if polity_ids:
         queryset = queryset.filter(polity__id__in=polity_ids)
 
+    if selected_event_ids:
+        queryset = queryset.filter(id__in=selected_event_ids)
+
     if selected_batches:
         queryset = queryset.filter(source=Instability_event.Source.LLM)
     elif selected_sources:
@@ -304,7 +450,14 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
     if name_query:
         queryset = queryset.filter(name__icontains=name_query)
 
-    queryset = apply_instability_row_quality_filter(queryset, selected_row_quality)
+    queryset = apply_instability_global_text_filter(queryset, selected_text_queries)
+
+    queryset = apply_instability_row_quality_filter(
+        queryset,
+        selected_row_quality,
+        excluded_ra_check_ids=excluded_ra_check_ids,
+        use_custom_excluded_ra_checks=use_custom_excluded_ra_checks,
+    )
 
     queryset = queryset.annotate(
         start_year_effective=Coalesce("year_from", F("polity__start_year")),
@@ -363,6 +516,360 @@ def get_filtered_instability_queryset(model_class, request):
     queryset = get_instability_list_queryset(model_class)
     queryset = apply_instability_event_filters(queryset, request)
     return apply_instability_event_ordering(queryset, request.GET.get("orderby"))
+
+
+def _token_query_matches(search_query, *values):
+    normalized_query = search_query.lower()
+    return any(normalized_query in str(value or "").lower() for value in values)
+
+
+def _build_instability_text_token(search_query):
+    if len(search_query) < 2:
+        return []
+
+    return [
+        FilterTokenOption(
+            kind="text",
+            value=search_query,
+            label=f'Search all fields for "{search_query}"',
+            group="Text Search",
+            meta="Event names, polities, labels, source, and batch",
+        )
+    ]
+
+
+def _build_instability_polity_tokens(base_queryset, search_query, limit):
+    polity_rows = (
+        base_queryset.filter(
+            Q(polity__name__icontains=search_query)
+            | Q(polity__long_name__icontains=search_query)
+            | Q(polity__new_name__icontains=search_query)
+        )
+        .values(
+            "polity_id",
+            "polity__long_name",
+            "polity__new_name",
+            "polity__start_year",
+            "polity__end_year",
+        )
+        .annotate(event_count=Count("id", distinct=True))
+        .order_by("-event_count", "polity__long_name")[:limit]
+    )
+
+    return [
+        FilterTokenOption(
+            kind="polity",
+            value=str(row["polity_id"]),
+            label=f"{row['polity__long_name']} ({row['polity__new_name']})",
+            group="Polities",
+            meta=(
+                f"{row['event_count']} events"
+                f" | {row['polity__start_year']} to {row['polity__end_year']}"
+            ),
+        )
+        for row in polity_rows
+        if row["polity_id"]
+    ]
+
+
+def _build_instability_event_tokens(base_queryset, search_query, limit):
+    events = (
+        base_queryset.filter(
+            Q(name__icontains=search_query) | Q(llm_name__icontains=search_query)
+        )
+        .select_related("polity")
+        .only("id", "name", "llm_name", "year_from", "year_to", "polity__long_name")
+        .order_by("name", "id")[:limit]
+    )
+
+    return [
+        FilterTokenOption(
+            kind="event",
+            value=str(event.id),
+            label=event.name or event.llm_name or f"Event {event.id}",
+            group="Events",
+            meta=(
+                f"{event.polity.long_name if event.polity_id else 'No polity'}"
+                f" | {event.year_from or '?'} to {event.year_to or '?'}"
+            ),
+        )
+        for event in events
+    ]
+
+
+def _build_instability_type_tokens(base_queryset, search_query, limit):
+    event_types = (
+        Instability_type.objects.filter(
+            name__icontains=search_query,
+            crisisdb_instability_events__in=base_queryset,
+        )
+        .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
+        .distinct()
+        .order_by("name")[:limit]
+    )
+
+    return [
+        FilterTokenOption(
+            kind="inst_type",
+            value=str(event_type.id),
+            label=event_type.name,
+            group="Event Types",
+            meta=f"{event_type.event_count} events",
+        )
+        for event_type in event_types
+    ]
+
+
+def _build_instability_check_tokens(base_queryset, search_query, limit):
+    check_choices = (
+        Check_choice.objects.filter(
+            name__icontains=search_query,
+            crisisdb_instability_events__in=base_queryset,
+        )
+        .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
+        .distinct()
+        .order_by("name")[:limit]
+    )
+
+    return [
+        FilterTokenOption(
+            kind="ra_check",
+            value=str(check.id),
+            label=check.name,
+            group="Researcher Checks",
+            meta=f"{check.event_count} events",
+        )
+        for check in check_choices
+    ]
+
+
+def _build_instability_source_tokens(base_queryset, search_query):
+    source_labels = {
+        Instability_event.Source.LLM: "LLM",
+        Instability_event.Source.MANUAL: "Manual",
+    }
+
+    tokens = []
+    for source, label in source_labels.items():
+        if _token_query_matches(search_query, source, label, "source"):
+            tokens.append(
+                FilterTokenOption(
+                    kind="source",
+                    value=source,
+                    label=label,
+                    group="Sources",
+                    meta=f"{base_queryset.filter(source=source).count()} events",
+                )
+            )
+    return tokens
+
+
+def _build_instability_batch_tokens(base_queryset, search_query):
+    tokens = []
+    llm_queryset = base_queryset.filter(source=Instability_event.Source.LLM)
+    for batch in VALID_INSTABILITY_BATCHES:
+        if _token_query_matches(search_query, batch, batch.replace(" ", "")):
+            tokens.append(
+                FilterTokenOption(
+                    kind="selected_batch",
+                    value=batch,
+                    label=batch,
+                    group="LLM Batches",
+                    meta=f"{apply_instability_batch_filter(llm_queryset, batch).count()} events",
+                )
+            )
+    return tokens
+
+
+def _build_instability_macro_event_record_tokens(base_queryset, search_query):
+    choices = (
+        (
+            "true",
+            "Macroevent records only",
+            ("macro", "macroevent", "macro event", "macroevent true", "true"),
+        ),
+        (
+            "false",
+            "Non-macroevent records only",
+            ("macro", "macroevent", "macro event", "macroevent false", "false"),
+        ),
+    )
+
+    tokens = []
+    for value, label, aliases in choices:
+        if _token_query_matches(search_query, label, *aliases):
+            tokens.append(
+                FilterTokenOption(
+                    kind="is_macro_event",
+                    value=value,
+                    label=label,
+                    group="Macroevent Record",
+                    meta=f"{base_queryset.filter(is_macro_event=(value == 'true')).count()} events",
+                )
+            )
+    return tokens
+
+
+def _build_instability_macro_event_tokens(base_queryset, search_query, limit):
+    candidates = base_queryset.filter(
+        Q(name__icontains="Macro Event") | Q(llm_name__icontains="Macro Event"),
+        Q(name__icontains=search_query) | Q(llm_name__icontains=search_query),
+    ).values_list("name", "llm_name")[:200]
+
+    macro_counts = Counter()
+    for name, llm_name in candidates:
+        macro_event = extract_macro_event_from_llm_name(llm_name or name)
+        if macro_event and _token_query_matches(search_query, macro_event):
+            macro_counts[macro_event] += 1
+
+    return [
+        FilterTokenOption(
+            kind="macro_event",
+            value=macro_event,
+            label=macro_event,
+            group="Umbrella Events",
+            meta=f"{count} events",
+        )
+        for macro_event, count in macro_counts.most_common(limit)
+    ]
+
+
+def build_instability_filter_token_options(search_query, limit=INSTABILITY_FILTER_TOKEN_LIMIT):
+    search_query = (search_query or "").strip()
+    if not search_query:
+        return []
+
+    base_queryset = get_instability_list_queryset(Instability_event)
+    return (
+        _build_instability_text_token(search_query)
+        + _build_instability_polity_tokens(base_queryset, search_query, limit)
+        + _build_instability_event_tokens(base_queryset, search_query, limit)
+        + _build_instability_macro_event_tokens(base_queryset, search_query, limit)
+        + _build_instability_type_tokens(base_queryset, search_query, limit)
+        + _build_instability_check_tokens(base_queryset, search_query, limit)
+        + _build_instability_source_tokens(base_queryset, search_query)
+        + _build_instability_batch_tokens(base_queryset, search_query)
+        + _build_instability_macro_event_record_tokens(base_queryset, search_query)
+    )
+
+
+def build_instability_filter_token_response(search_query):
+    return build_grouped_token_response(
+        build_instability_filter_token_options(search_query)
+    )
+
+
+def build_selected_instability_filter_token_options(request):
+    options = []
+
+    for text_query in get_selected_instability_text_queries(request):
+        options.append(
+            FilterTokenOption(
+                kind="text",
+                value=text_query,
+                label=f'Search all fields for "{text_query}"',
+                group="Text Search",
+            )
+        )
+
+    for polity in Polity.objects.filter(
+        id__in=get_request_list(request, "polity")
+    ).order_by("long_name"):
+        options.append(
+            FilterTokenOption(
+                kind="polity",
+                value=str(polity.id),
+                label=f"{polity.long_name} ({polity.new_name})",
+                group="Polities",
+            )
+        )
+
+    for event in get_instability_list_queryset(Instability_event).filter(
+        id__in=get_selected_instability_event_ids(request)
+    ).select_related("polity"):
+        options.append(
+            FilterTokenOption(
+                kind="event",
+                value=str(event.id),
+                label=event.name or event.llm_name or f"Event {event.id}",
+                group="Events",
+            )
+        )
+
+    for macro_event in get_request_list(request, "macro_event"):
+        options.append(
+            FilterTokenOption(
+                kind="macro_event",
+                value=macro_event,
+                label=macro_event,
+                group="Umbrella Events",
+            )
+        )
+
+    selected_is_macro_event = request.GET.get("is_macro_event")
+    if selected_is_macro_event in {"true", "false"}:
+        options.append(
+            FilterTokenOption(
+                kind="is_macro_event",
+                value=selected_is_macro_event,
+                label=(
+                    "Macroevent records only"
+                    if selected_is_macro_event == "true"
+                    else "Non-macroevent records only"
+                ),
+                group="Macroevent Record",
+            )
+        )
+
+    for event_type in Instability_type.objects.filter(
+        id__in=get_request_list(request, "inst_type")
+    ).order_by("name"):
+        options.append(
+            FilterTokenOption(
+                kind="inst_type",
+                value=str(event_type.id),
+                label=event_type.name,
+                group="Event Types",
+            )
+        )
+
+    for check in Check_choice.objects.filter(
+        id__in=get_request_list(request, "ra_check")
+    ).order_by("name"):
+        options.append(
+            FilterTokenOption(
+                kind="ra_check",
+                value=str(check.id),
+                label=check.name,
+                group="Researcher Checks",
+            )
+        )
+
+    source_labels = {
+        Instability_event.Source.LLM: "LLM",
+        Instability_event.Source.MANUAL: "Manual",
+    }
+    for source in get_selected_instability_sources(request):
+        options.append(
+            FilterTokenOption(
+                kind="source",
+                value=source,
+                label=source_labels.get(source, source.title()),
+                group="Sources",
+            )
+        )
+
+    for batch in get_selected_instability_batches(request):
+        options.append(
+            FilterTokenOption(
+                kind="selected_batch",
+                value=batch,
+                label=batch,
+                group="LLM Batches",
+            )
+        )
+
+    return options
 
 
 def get_instability_filter_option_queryset(model_class, request, ignored_filters=None):
@@ -444,8 +951,11 @@ def build_instability_list_context(model_class, request):
     selected_row_quality = get_selected_row_quality(request)
     selected_polity_ids = get_request_list(request, "polity")
     selected_macro_events = get_request_list(request, "macro_event")
+    selected_event_ids = get_selected_instability_event_ids(request)
+    selected_text_queries = get_selected_instability_text_queries(request)
     selected_inst_type_ids = get_request_list(request, "inst_type")
     selected_ra_check_ids = get_request_list(request, "ra_check")
+    selected_excluded_ra_check_ids = get_selected_excluded_ra_check_ids(request)
     selected_inst_extent_values = get_request_list(request, "inst_extent")
     selected_inst_intensity_values = get_request_list(request, "inst_intensity")
 
@@ -468,6 +978,15 @@ def build_instability_list_context(model_class, request):
         model_class,
         request,
         ignored_filters={"ra_check"},
+    )
+    excluded_ra_check_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={
+            EXCLUDED_RA_CHECK_PARAM,
+            EXCLUDED_RA_CHECK_MODE_PARAM,
+            "row_quality",
+        },
     )
     inst_extent_option_queryset = get_instability_filter_option_queryset(
         model_class,
@@ -585,6 +1104,27 @@ def build_instability_list_context(model_class, request):
         for batch in VALID_INSTABILITY_BATCHES
         if batch_counts.get(batch, 0) or batch in selected_batch_values
     ]
+    selected_event_filters = list(
+        get_instability_list_queryset(model_class)
+        .filter(id__in=selected_event_ids)
+        .select_related("polity")
+        .order_by("name", "id")
+    )
+    excluded_ra_check_choices = list(
+        Check_choice.objects.filter(
+            Q(crisisdb_instability_events__in=excluded_ra_check_option_queryset)
+            | Q(id__in=selected_excluded_ra_check_ids)
+            | Q(name__in=GOOD_ROW_EXCLUDED_CHECK_NAMES)
+        )
+        .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
+        .distinct()
+        .order_by("name")
+    )
+    selected_excluded_ra_check_labels = [
+        check.name
+        for check in excluded_ra_check_choices
+        if str(check.id) in selected_excluded_ra_check_ids
+    ]
 
     return {
         "polities": enriched_polities,
@@ -607,6 +1147,9 @@ def build_instability_list_context(model_class, request):
         "macro_events": [event for event, _count in macro_events_with_counts],
         "selected_macro": selected_macro_events[0] if len(selected_macro_events) == 1 else None,
         "selected_macro_events": selected_macro_events,
+        "selected_event_ids": selected_event_ids,
+        "selected_event_filters": selected_event_filters,
+        "selected_text_queries": selected_text_queries,
         "selected_is_macro_event": request.GET.get("is_macro_event"),
         "name_query": request.GET.get("searched_name", "").strip(),
         "selected_source": selected_source,
@@ -615,6 +1158,10 @@ def build_instability_list_context(model_class, request):
         "selected_batch_values": selected_batch_values,
         "batch_filter_forces_llm": batch_filter_forces_llm,
         "selected_row_quality": selected_row_quality,
+        "default_excluded_ra_check_ids": get_default_excluded_ra_check_ids(),
+        "excluded_ra_check_choices": excluded_ra_check_choices,
+        "selected_excluded_ra_check_ids": selected_excluded_ra_check_ids,
+        "selected_excluded_ra_check_labels": selected_excluded_ra_check_labels,
         "show_llm_batch_filter": True,
         "selected_polity_ids": selected_polity_ids,
         "selected_inst_type_ids": selected_inst_type_ids,
@@ -622,6 +1169,7 @@ def build_instability_list_context(model_class, request):
         "selected_inst_extent_values": selected_inst_extent_values,
         "selected_inst_intensity_values": selected_inst_intensity_values,
         "active_filter_count": get_active_instability_filter_count(request),
+        "selected_global_filter_tokens": build_selected_instability_filter_token_options(request),
         "source_filter_choices": source_filter_choices,
         "batch_filter_choices": batch_filter_choices,
         "inst_extent_filter_choices": inst_extent_filter_choices,

--- a/seshat/apps/crisisdb/instability_filters.py
+++ b/seshat/apps/crisisdb/instability_filters.py
@@ -6,7 +6,13 @@ from django.db.models.functions import Cast, Coalesce
 from django.utils.dateparse import parse_date
 from django.utils import timezone
 
-from ..core.filter_tokens import FilterTokenOption, build_grouped_token_response
+from ..core.filter_tokens import (
+    FilterTokenOption,
+    build_grouped_token_response,
+    build_term_search_query,
+    get_search_terms,
+    normalize_search_text,
+)
 from ..core.models import Polity
 from .models import (
     Check_choice,
@@ -45,6 +51,17 @@ VALID_INSTABILITY_BATCHES = (
     "Batch 4",
 )
 INSTABILITY_FILTER_TOKEN_LIMIT = 8
+INSTABILITY_FILTER_TOKEN_GROUP_ORDER = (
+    "Sources",
+    "LLM Batches",
+    "Macroevent",
+    "Polities",
+    "Event Types",
+    "Researcher Checks",
+    "Text Search",
+    "Events",
+    "Umbrella Events",
+)
 
 
 def get_batch_tag(created_date):
@@ -134,11 +151,28 @@ def get_request_list(request, key):
     return values
 
 
+def get_selected_ra_check_ids(request):
+    return [
+        value
+        for value in get_request_list(request, "ra_check")
+        if value.isdigit()
+    ]
+
+
+def exclude_required_ra_check_ids(request, check_ids):
+    required_check_ids = set(get_selected_ra_check_ids(request))
+    return [
+        check_id
+        for check_id in check_ids
+        if check_id not in required_check_ids
+    ]
+
+
 def get_selected_row_quality(request):
     selected_row_quality = request.GET.get("row_quality")
     if selected_row_quality == GOOD_ROW_FILTER:
         return selected_row_quality
-    if any(value.strip() for value in request.GET.getlist(EXCLUDED_RA_CHECK_PARAM)):
+    if get_custom_excluded_ra_check_ids(request):
         return GOOD_ROW_FILTER
     return None
 
@@ -157,16 +191,21 @@ def get_default_excluded_ra_check_ids():
 def uses_custom_excluded_ra_checks(request):
     return (
         request.GET.get(EXCLUDED_RA_CHECK_MODE_PARAM) == CUSTOM_EXCLUDED_RA_CHECK_MODE
-        or bool(get_custom_excluded_ra_check_ids(request))
+        or bool(get_raw_custom_excluded_ra_check_ids(request))
     )
 
 
-def get_custom_excluded_ra_check_ids(request):
+def get_raw_custom_excluded_ra_check_ids(request):
     return [
         value
         for value in get_request_list(request, EXCLUDED_RA_CHECK_PARAM)
         if value.isdigit()
     ]
+
+
+def get_custom_excluded_ra_check_ids(request):
+    custom_check_ids = get_raw_custom_excluded_ra_check_ids(request)
+    return exclude_required_ra_check_ids(request, custom_check_ids)
 
 
 def get_selected_excluded_ra_check_ids(request):
@@ -176,7 +215,7 @@ def get_selected_excluded_ra_check_ids(request):
     if uses_custom_excluded_ra_checks(request):
         return get_custom_excluded_ra_check_ids(request)
 
-    return get_default_excluded_ra_check_ids()
+    return exclude_required_ra_check_ids(request, get_default_excluded_ra_check_ids())
 
 
 def build_macro_event_filter_query(selected_macro_events):
@@ -193,10 +232,9 @@ def apply_instability_row_quality_filter(
     queryset,
     selected_row_quality,
     excluded_ra_check_ids=None,
-    use_custom_excluded_ra_checks=False,
 ):
     if selected_row_quality == GOOD_ROW_FILTER:
-        if use_custom_excluded_ra_checks:
+        if excluded_ra_check_ids is not None:
             if not excluded_ra_check_ids:
                 return queryset
             return queryset.exclude(ra_check__id__in=excluded_ra_check_ids).distinct()
@@ -271,12 +309,12 @@ def get_active_instability_filter_count(request):
     selected_batches = get_selected_instability_batches(request)
     selected_sources = get_selected_instability_sources(request)
     if selected_batches:
-        active_count += 1
+        # Batch filters imply LLM-only results and each selected batch is shown as a chip.
+        active_count += 1 + len(selected_batches)
     else:
         active_count += len(selected_sources)
     if get_selected_row_quality(request):
         active_count += 1
-    active_count += len(selected_batches)
     if request.GET.get("is_macro_event") in {"true", "false"}:
         active_count += 1
     if request.GET.get("searched_name", "").strip():
@@ -298,16 +336,19 @@ def apply_instability_event_source_filter(queryset, request):
 
 def build_instability_global_text_query(text_values):
     global_query = Q()
+    searchable_fields = (
+        "name",
+        "llm_name",
+        "polity__name",
+        "polity__long_name",
+        "polity__new_name",
+        "inst_type__name",
+        "ra_check__name",
+    )
     for text_value in text_values:
-        item_query = (
-            Q(name__icontains=text_value)
-            | Q(llm_name__icontains=text_value)
-            | Q(polity__name__icontains=text_value)
-            | Q(polity__long_name__icontains=text_value)
-            | Q(polity__new_name__icontains=text_value)
-            | Q(inst_type__name__icontains=text_value)
-            | Q(ra_check__name__icontains=text_value)
-        )
+        if not get_search_terms(text_value):
+            continue
+        item_query = build_term_search_query(text_value, searchable_fields)
 
         matching_sources = [
             source
@@ -346,7 +387,16 @@ def build_instability_global_text_query(text_values):
 def apply_instability_global_text_filter(queryset, text_values):
     if not text_values:
         return queryset
-    return queryset.filter(build_instability_global_text_query(text_values)).distinct()
+    searchable_text_values = [
+        text_value
+        for text_value in text_values
+        if get_search_terms(text_value)
+    ]
+    if not searchable_text_values:
+        return queryset.none()
+    return queryset.filter(
+        build_instability_global_text_query(searchable_text_values)
+    ).distinct()
 
 
 def apply_instability_event_filters(queryset, request, ignored_filters=None):
@@ -379,7 +429,7 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
         [] if "inst_type" in ignored_filters else get_request_list(request, "inst_type")
     )
     ra_check_ids = (
-        [] if "ra_check" in ignored_filters else get_request_list(request, "ra_check")
+        [] if "ra_check" in ignored_filters else get_selected_ra_check_ids(request)
     )
     inst_extent_values = (
         [] if "inst_extent" in ignored_filters else get_request_list(request, "inst_extent")
@@ -411,11 +461,6 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
         []
         if EXCLUDED_RA_CHECK_PARAM in ignored_filters or "row_quality" in ignored_filters
         else get_selected_excluded_ra_check_ids(request)
-    )
-    use_custom_excluded_ra_checks = (
-        False
-        if EXCLUDED_RA_CHECK_MODE_PARAM in ignored_filters or "row_quality" in ignored_filters
-        else uses_custom_excluded_ra_checks(request)
     )
 
     if inst_type_ids:
@@ -456,7 +501,6 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
         queryset,
         selected_row_quality,
         excluded_ra_check_ids=excluded_ra_check_ids,
-        use_custom_excluded_ra_checks=use_custom_excluded_ra_checks,
     )
 
     queryset = queryset.annotate(
@@ -519,8 +563,19 @@ def get_filtered_instability_queryset(model_class, request):
 
 
 def _token_query_matches(search_query, *values):
-    normalized_query = search_query.lower()
-    return any(normalized_query in str(value or "").lower() for value in values)
+    terms = get_search_terms(search_query)
+    if not terms:
+        return False
+
+    normalized_values = [
+        normalize_search_text(value)
+        for value in values
+        if str(value or "").strip()
+    ]
+    return all(
+        any(term in normalized_value for normalized_value in normalized_values)
+        for term in terms
+    )
 
 
 def _build_instability_text_token(search_query):
@@ -541,9 +596,14 @@ def _build_instability_text_token(search_query):
 def _build_instability_polity_tokens(base_queryset, search_query, limit):
     polity_rows = (
         base_queryset.filter(
-            Q(polity__name__icontains=search_query)
-            | Q(polity__long_name__icontains=search_query)
-            | Q(polity__new_name__icontains=search_query)
+            build_term_search_query(
+                search_query,
+                (
+                    "polity__name",
+                    "polity__long_name",
+                    "polity__new_name",
+                ),
+            )
         )
         .values(
             "polity_id",
@@ -575,7 +635,15 @@ def _build_instability_polity_tokens(base_queryset, search_query, limit):
 def _build_instability_event_tokens(base_queryset, search_query, limit):
     events = (
         base_queryset.filter(
-            Q(name__icontains=search_query) | Q(llm_name__icontains=search_query)
+            build_term_search_query(
+                search_query,
+                (
+                    "name",
+                    "llm_name",
+                    "polity__long_name",
+                    "polity__new_name",
+                ),
+            )
         )
         .select_related("polity")
         .only("id", "name", "llm_name", "year_from", "year_to", "polity__long_name")
@@ -600,7 +668,7 @@ def _build_instability_event_tokens(base_queryset, search_query, limit):
 def _build_instability_type_tokens(base_queryset, search_query, limit):
     event_types = (
         Instability_type.objects.filter(
-            name__icontains=search_query,
+            build_term_search_query(search_query, ("name",)),
             crisisdb_instability_events__in=base_queryset,
         )
         .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
@@ -623,7 +691,7 @@ def _build_instability_type_tokens(base_queryset, search_query, limit):
 def _build_instability_check_tokens(base_queryset, search_query, limit):
     check_choices = (
         Check_choice.objects.filter(
-            name__icontains=search_query,
+            build_term_search_query(search_query, ("name",)),
             crisisdb_instability_events__in=base_queryset,
         )
         .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
@@ -685,13 +753,36 @@ def _build_instability_macro_event_record_tokens(base_queryset, search_query):
     choices = (
         (
             "true",
-            "Macroevent records only",
-            ("macro", "macroevent", "macro event", "macroevent true", "true"),
+            "Macro events only",
+            (
+                "macro",
+                "macroevent",
+                "macro event",
+                "macroevent true",
+                "record",
+                "record type",
+                "true",
+            ),
         ),
         (
             "false",
-            "Non-macroevent records only",
-            ("macro", "macroevent", "macro event", "macroevent false", "false"),
+            "Normal events only",
+            (
+                "macro",
+                "macroevent",
+                "macro event",
+                "macroevent false",
+                "non macro",
+                "non-macroevent",
+                "record",
+                "record type",
+                "normal",
+                "normal event",
+                "normal events",
+                "single event",
+                "single-event",
+                "false",
+            ),
         ),
     )
 
@@ -703,7 +794,7 @@ def _build_instability_macro_event_record_tokens(base_queryset, search_query):
                     kind="is_macro_event",
                     value=value,
                     label=label,
-                    group="Macroevent Record",
+                    group="Macroevent",
                     meta=f"{base_queryset.filter(is_macro_event=(value == 'true')).count()} events",
                 )
             )
@@ -713,7 +804,7 @@ def _build_instability_macro_event_record_tokens(base_queryset, search_query):
 def _build_instability_macro_event_tokens(base_queryset, search_query, limit):
     candidates = base_queryset.filter(
         Q(name__icontains="Macro Event") | Q(llm_name__icontains="Macro Event"),
-        Q(name__icontains=search_query) | Q(llm_name__icontains=search_query),
+        build_term_search_query(search_query, ("name", "llm_name")),
     ).values_list("name", "llm_name")[:200]
 
     macro_counts = Counter()
@@ -736,26 +827,27 @@ def _build_instability_macro_event_tokens(base_queryset, search_query, limit):
 
 def build_instability_filter_token_options(search_query, limit=INSTABILITY_FILTER_TOKEN_LIMIT):
     search_query = (search_query or "").strip()
-    if not search_query:
+    if not search_query or not get_search_terms(search_query):
         return []
 
     base_queryset = get_instability_list_queryset(Instability_event)
     return (
-        _build_instability_text_token(search_query)
-        + _build_instability_polity_tokens(base_queryset, search_query, limit)
-        + _build_instability_event_tokens(base_queryset, search_query, limit)
-        + _build_instability_macro_event_tokens(base_queryset, search_query, limit)
-        + _build_instability_type_tokens(base_queryset, search_query, limit)
-        + _build_instability_check_tokens(base_queryset, search_query, limit)
-        + _build_instability_source_tokens(base_queryset, search_query)
+        _build_instability_source_tokens(base_queryset, search_query)
         + _build_instability_batch_tokens(base_queryset, search_query)
         + _build_instability_macro_event_record_tokens(base_queryset, search_query)
+        + _build_instability_polity_tokens(base_queryset, search_query, limit)
+        + _build_instability_type_tokens(base_queryset, search_query, limit)
+        + _build_instability_check_tokens(base_queryset, search_query, limit)
+        + _build_instability_text_token(search_query)
+        + _build_instability_event_tokens(base_queryset, search_query, limit)
+        + _build_instability_macro_event_tokens(base_queryset, search_query, limit)
     )
 
 
 def build_instability_filter_token_response(search_query):
     return build_grouped_token_response(
-        build_instability_filter_token_options(search_query)
+        build_instability_filter_token_options(search_query),
+        group_order=INSTABILITY_FILTER_TOKEN_GROUP_ORDER,
     )
 
 
@@ -813,11 +905,11 @@ def build_selected_instability_filter_token_options(request):
                 kind="is_macro_event",
                 value=selected_is_macro_event,
                 label=(
-                    "Macroevent records only"
+                    "Macro events only"
                     if selected_is_macro_event == "true"
-                    else "Non-macroevent records only"
+                    else "Normal events only"
                 ),
-                group="Macroevent Record",
+                group="Macroevent",
             )
         )
 
@@ -834,7 +926,7 @@ def build_selected_instability_filter_token_options(request):
         )
 
     for check in Check_choice.objects.filter(
-        id__in=get_request_list(request, "ra_check")
+        id__in=get_selected_ra_check_ids(request)
     ).order_by("name"):
         options.append(
             FilterTokenOption(
@@ -942,10 +1034,16 @@ def build_instability_json_coded_values(event):
 def build_instability_list_context(model_class, request):
     selected_batch_values = get_selected_instability_batches(request)
     batch_filter_forces_llm = bool(selected_batch_values)
+    explicit_selected_source_values = get_selected_instability_sources(request)
+    explicit_selected_source = (
+        explicit_selected_source_values[0]
+        if len(explicit_selected_source_values) == 1
+        else None
+    )
     selected_sources = (
         [Instability_event.Source.LLM]
         if batch_filter_forces_llm
-        else get_selected_instability_sources(request)
+        else explicit_selected_source_values
     )
     selected_source = selected_sources[0] if len(selected_sources) == 1 else None
     selected_row_quality = get_selected_row_quality(request)
@@ -954,7 +1052,7 @@ def build_instability_list_context(model_class, request):
     selected_event_ids = get_selected_instability_event_ids(request)
     selected_text_queries = get_selected_instability_text_queries(request)
     selected_inst_type_ids = get_request_list(request, "inst_type")
-    selected_ra_check_ids = get_request_list(request, "ra_check")
+    selected_ra_check_ids = get_selected_ra_check_ids(request)
     selected_excluded_ra_check_ids = get_selected_excluded_ra_check_ids(request)
     selected_inst_extent_values = get_request_list(request, "inst_extent")
     selected_inst_intensity_values = get_request_list(request, "inst_intensity")
@@ -1154,6 +1252,8 @@ def build_instability_list_context(model_class, request):
         "name_query": request.GET.get("searched_name", "").strip(),
         "selected_source": selected_source,
         "selected_source_values": selected_sources,
+        "explicit_selected_source": explicit_selected_source,
+        "explicit_selected_source_values": explicit_selected_source_values,
         "selected_batch": selected_batch_values[0] if len(selected_batch_values) == 1 else None,
         "selected_batch_values": selected_batch_values,
         "batch_filter_forces_llm": batch_filter_forces_llm,

--- a/seshat/apps/crisisdb/instability_filters.py
+++ b/seshat/apps/crisisdb/instability_filters.py
@@ -31,6 +31,16 @@ GOOD_ROW_EXCLUDED_CHECK_NAMES = frozenset(
         "External Event",
     }
 )
+VALID_INSTABILITY_SOURCES = (
+    Instability_event.Source.LLM,
+    Instability_event.Source.MANUAL,
+)
+VALID_INSTABILITY_BATCHES = (
+    "Batch 1",
+    "Batch 2",
+    "Batch 3",
+    "Batch 4",
+)
 
 
 def get_batch_tag(created_date):
@@ -69,25 +79,41 @@ def get_batch_tooltip(created_date):
     return "Generated on or after March 1st, 2026."
 
 
-def apply_instability_batch_filter(queryset, selected_batch):
-    if not selected_batch:
+def normalize_instability_batches(selected_batches):
+    if not selected_batches:
+        return []
+
+    if isinstance(selected_batches, str):
+        selected_batches = [selected_batches]
+
+    normalized_batches = []
+    for batch in selected_batches:
+        if batch in VALID_INSTABILITY_BATCHES and batch not in normalized_batches:
+            normalized_batches.append(batch)
+    return normalized_batches
+
+
+def apply_instability_batch_filter(queryset, selected_batches):
+    selected_batches = normalize_instability_batches(selected_batches)
+    if not selected_batches:
         return queryset
 
-    if selected_batch == "Batch 1":
-        return queryset.filter(created_date__lt=BATCH_1_END_DATETIME)
-    if selected_batch == "Batch 2":
-        return queryset.filter(
+    batch_query = Q()
+    if "Batch 1" in selected_batches:
+        batch_query |= Q(created_date__lt=BATCH_1_END_DATETIME)
+    if "Batch 2" in selected_batches:
+        batch_query |= Q(
             created_date__gte=BATCH_1_END_DATETIME,
             created_date__lt=BATCH_2_END_DATETIME,
         )
-    if selected_batch == "Batch 3":
-        return queryset.filter(
+    if "Batch 3" in selected_batches:
+        batch_query |= Q(
             created_date__gte=BATCH_2_END_DATETIME,
             created_date__lt=BATCH_3_END_DATETIME,
         )
-    if selected_batch == "Batch 4":
-        return queryset.filter(created_date__gte=BATCH_3_END_DATETIME)
-    return queryset
+    if "Batch 4" in selected_batches:
+        batch_query |= Q(created_date__gte=BATCH_3_END_DATETIME)
+    return queryset.filter(batch_query)
 
 
 def get_request_list(request, key):
@@ -136,16 +162,63 @@ def get_polity_instability_queryset(polity_id, selected_source=None, selected_ba
 
 
 def get_selected_instability_source(request):
-    selected_source = request.GET.get("source")
-    if selected_source in {Instability_event.Source.LLM, Instability_event.Source.MANUAL}:
-        return selected_source
+    selected_sources = get_selected_instability_sources(request)
+    if len(selected_sources) == 1:
+        return selected_sources[0]
     return None
 
 
+def get_selected_instability_sources(request):
+    selected_sources = []
+    for source in get_request_list(request, "source"):
+        if source in VALID_INSTABILITY_SOURCES and source not in selected_sources:
+            selected_sources.append(source)
+    return selected_sources
+
+
+def get_selected_instability_batches(request):
+    return normalize_instability_batches(get_request_list(request, "selected_batch"))
+
+
+def get_active_instability_filter_count(request):
+    multi_value_filters = (
+        "polity",
+        "macro_event",
+        "inst_type",
+        "ra_check",
+        "inst_extent",
+        "inst_intensity",
+    )
+    active_count = sum(
+        len(get_request_list(request, filter_name))
+        for filter_name in multi_value_filters
+    )
+
+    selected_batches = get_selected_instability_batches(request)
+    selected_sources = get_selected_instability_sources(request)
+    if selected_batches:
+        active_count += 1
+    else:
+        active_count += len(selected_sources)
+    if get_selected_row_quality(request):
+        active_count += 1
+    active_count += len(selected_batches)
+    if request.GET.get("is_macro_event") in {"true", "false"}:
+        active_count += 1
+    if request.GET.get("searched_name", "").strip():
+        active_count += 1
+    if request.GET.get("year_from_min"):
+        active_count += 1
+    if request.GET.get("year_to_max"):
+        active_count += 1
+
+    return active_count
+
+
 def apply_instability_event_source_filter(queryset, request):
-    selected_source = get_selected_instability_source(request)
-    if selected_source:
-        return queryset.filter(source=selected_source)
+    selected_sources = get_selected_instability_sources(request)
+    if selected_sources:
+        return queryset.filter(source__in=selected_sources)
     return queryset
 
 
@@ -160,11 +233,13 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
     created_before = (
         None if "created_before" in ignored_filters else request.GET.get("created_before")
     )
-    selected_batch = (
-        None if "selected_batch" in ignored_filters else request.GET.get("selected_batch")
+    selected_batches = (
+        []
+        if "selected_batch" in ignored_filters
+        else get_selected_instability_batches(request)
     )
-    selected_source = (
-        None if "source" in ignored_filters else get_selected_instability_source(request)
+    selected_sources = (
+        [] if "source" in ignored_filters else get_selected_instability_sources(request)
     )
     polity_ids = [] if "polity" in ignored_filters else get_request_list(request, "polity")
     inst_type_ids = (
@@ -215,8 +290,10 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
     if polity_ids:
         queryset = queryset.filter(polity__id__in=polity_ids)
 
-    if selected_source:
-        queryset = queryset.filter(source=selected_source)
+    if selected_batches:
+        queryset = queryset.filter(source=Instability_event.Source.LLM)
+    elif selected_sources:
+        queryset = queryset.filter(source__in=selected_sources)
 
     if selected_macro_events:
         queryset = queryset.filter(build_macro_event_filter_query(selected_macro_events))
@@ -245,9 +322,8 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
         if parsed_date:
             queryset = queryset.filter(created_date__lt=parsed_date)
 
-    if selected_batch and selected_source != Instability_event.Source.MANUAL:
-        queryset = queryset.filter(source=Instability_event.Source.LLM)
-        queryset = apply_instability_batch_filter(queryset, selected_batch)
+    if selected_batches:
+        queryset = apply_instability_batch_filter(queryset, selected_batches)
 
     return queryset
 
@@ -357,8 +433,14 @@ def build_instability_json_coded_values(event):
 
 
 def build_instability_list_context(model_class, request):
-    selected_source = get_selected_instability_source(request)
-    selected_batch = request.GET.get("selected_batch")
+    selected_batch_values = get_selected_instability_batches(request)
+    batch_filter_forces_llm = bool(selected_batch_values)
+    selected_sources = (
+        [Instability_event.Source.LLM]
+        if batch_filter_forces_llm
+        else get_selected_instability_sources(request)
+    )
+    selected_source = selected_sources[0] if len(selected_sources) == 1 else None
     selected_row_quality = get_selected_row_quality(request)
     selected_polity_ids = get_request_list(request, "polity")
     selected_macro_events = get_request_list(request, "macro_event")
@@ -396,6 +478,16 @@ def build_instability_list_context(model_class, request):
         model_class,
         request,
         ignored_filters={"inst_intensity"},
+    )
+    batch_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={"selected_batch", "source"},
+    )
+    source_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={"source"},
     )
 
     polity_counts = {
@@ -466,6 +558,33 @@ def build_instability_list_context(model_class, request):
         for value, label in INST_INTENSITY_CHOICES
         if inst_intensity_counts.get(value, 0) or value in selected_inst_intensity_values
     ]
+    source_counts = {
+        row["source"]: row["event_count"]
+        for row in source_option_queryset.values("source").annotate(
+            event_count=Count("id", distinct=True)
+        )
+    }
+    source_filter_choices = [
+        (Instability_event.Source.LLM, "LLM", source_counts.get(Instability_event.Source.LLM, 0)),
+        (
+            Instability_event.Source.MANUAL,
+            "Manual",
+            source_counts.get(Instability_event.Source.MANUAL, 0),
+        ),
+    ]
+    batch_counts = Counter(
+        get_batch_tag(created_date)
+        for source, created_date in batch_option_queryset.values_list(
+            "source",
+            "created_date",
+        )
+        if source == Instability_event.Source.LLM and created_date is not None
+    )
+    batch_filter_choices = [
+        (batch, batch_counts.get(batch, 0))
+        for batch in VALID_INSTABILITY_BATCHES
+        if batch_counts.get(batch, 0) or batch in selected_batch_values
+    ]
 
     return {
         "polities": enriched_polities,
@@ -491,14 +610,20 @@ def build_instability_list_context(model_class, request):
         "selected_is_macro_event": request.GET.get("is_macro_event"),
         "name_query": request.GET.get("searched_name", "").strip(),
         "selected_source": selected_source,
-        "selected_batch": selected_batch,
+        "selected_source_values": selected_sources,
+        "selected_batch": selected_batch_values[0] if len(selected_batch_values) == 1 else None,
+        "selected_batch_values": selected_batch_values,
+        "batch_filter_forces_llm": batch_filter_forces_llm,
         "selected_row_quality": selected_row_quality,
-        "show_llm_batch_filter": selected_source != Instability_event.Source.MANUAL,
+        "show_llm_batch_filter": True,
         "selected_polity_ids": selected_polity_ids,
         "selected_inst_type_ids": selected_inst_type_ids,
         "selected_ra_check_ids": selected_ra_check_ids,
         "selected_inst_extent_values": selected_inst_extent_values,
         "selected_inst_intensity_values": selected_inst_intensity_values,
+        "active_filter_count": get_active_instability_filter_count(request),
+        "source_filter_choices": source_filter_choices,
+        "batch_filter_choices": batch_filter_choices,
         "inst_extent_filter_choices": inst_extent_filter_choices,
         "inst_intensity_filter_choices": inst_intensity_filter_choices,
         "INST_EXTENT_CHOICES": INST_EXTENT_CHOICES,

--- a/seshat/apps/crisisdb/instability_filters.py
+++ b/seshat/apps/crisisdb/instability_filters.py
@@ -12,6 +12,7 @@ from ..core.filter_tokens import (
     build_term_search_query,
     get_search_terms,
     normalize_search_text,
+    parse_integer_filter_value,
 )
 from ..core.models import Polity
 from .models import (
@@ -290,6 +291,10 @@ def get_selected_instability_text_queries(request):
     return get_request_list(request, "q")
 
 
+def get_selected_instability_year(request, parameter_name):
+    return parse_integer_filter_value(request.GET.get(parameter_name))
+
+
 def get_active_instability_filter_count(request):
     multi_value_filters = (
         "polity",
@@ -319,9 +324,9 @@ def get_active_instability_filter_count(request):
         active_count += 1
     if request.GET.get("searched_name", "").strip():
         active_count += 1
-    if request.GET.get("year_from_min"):
+    if get_selected_instability_year(request, "year_from_min") is not None:
         active_count += 1
-    if request.GET.get("year_to_max"):
+    if get_selected_instability_year(request, "year_to_max") is not None:
         active_count += 1
 
     return active_count
@@ -402,10 +407,14 @@ def apply_instability_global_text_filter(queryset, text_values):
 def apply_instability_event_filters(queryset, request, ignored_filters=None):
     ignored_filters = set(ignored_filters or [])
     year_from_min = (
-        None if "year_from_min" in ignored_filters else request.GET.get("year_from_min")
+        None
+        if "year_from_min" in ignored_filters
+        else get_selected_instability_year(request, "year_from_min")
     )
     year_to_max = (
-        None if "year_to_max" in ignored_filters else request.GET.get("year_to_max")
+        None
+        if "year_to_max" in ignored_filters
+        else get_selected_instability_year(request, "year_to_max")
     )
     created_before = (
         None if "created_before" in ignored_filters else request.GET.get("created_before")
@@ -508,11 +517,11 @@ def apply_instability_event_filters(queryset, request, ignored_filters=None):
         end_year_effective=Coalesce("year_to", F("polity__end_year")),
     )
 
-    if year_from_min:
-        queryset = queryset.filter(start_year_effective__gte=int(year_from_min))
+    if year_from_min is not None:
+        queryset = queryset.filter(start_year_effective__gte=year_from_min)
 
-    if year_to_max:
-        queryset = queryset.filter(end_year_effective__lte=int(year_to_max))
+    if year_to_max is not None:
+        queryset = queryset.filter(end_year_effective__lte=year_to_max)
 
     if created_before:
         parsed_date = parse_date(created_before)
@@ -1054,8 +1063,20 @@ def build_instability_list_context(model_class, request):
     selected_inst_type_ids = get_request_list(request, "inst_type")
     selected_ra_check_ids = get_selected_ra_check_ids(request)
     selected_excluded_ra_check_ids = get_selected_excluded_ra_check_ids(request)
+    default_excluded_ra_check_ids = get_default_excluded_ra_check_ids()
+    effective_default_excluded_ids = exclude_required_ra_check_ids(
+        request,
+        default_excluded_ra_check_ids,
+    )
+    default_invalid_filter_active = (
+        selected_row_quality == GOOD_ROW_FILTER
+        and bool(effective_default_excluded_ids)
+        and set(selected_excluded_ra_check_ids) == set(effective_default_excluded_ids)
+    )
     selected_inst_extent_values = get_request_list(request, "inst_extent")
     selected_inst_intensity_values = get_request_list(request, "inst_intensity")
+    selected_year_from_min = get_selected_instability_year(request, "year_from_min")
+    selected_year_to_max = get_selected_instability_year(request, "year_to_max")
 
     polity_option_queryset = get_instability_filter_option_queryset(
         model_class,
@@ -1114,7 +1135,13 @@ def build_instability_list_context(model_class, request):
         )
         if row["polity_id"] is not None
     }
-    polities = list(Polity.objects.filter(id__in=polity_counts).order_by("new_name"))
+    polity_option_ids = set(polity_counts)
+    polity_option_ids.update(
+        int(polity_id) for polity_id in selected_polity_ids if polity_id.isdigit()
+    )
+    polities = list(
+        Polity.objects.filter(id__in=polity_option_ids).order_by("new_name")
+    )
 
     macro_event_list = [
         obj.made_up_macro_event
@@ -1122,6 +1149,8 @@ def build_instability_list_context(model_class, request):
         if obj.made_up_macro_event
     ]
     macro_event_counts = Counter(macro_event_list)
+    for selected_macro_event in selected_macro_events:
+        macro_event_counts.setdefault(selected_macro_event, 0)
     macro_events_with_counts = sorted(
         macro_event_counts.items(),
         key=lambda item: (-item[1], item[0]),
@@ -1208,6 +1237,49 @@ def build_instability_list_context(model_class, request):
         .select_related("polity")
         .order_by("name", "id")
     )
+    selected_polity_filters = list(
+        Polity.objects.filter(id__in=selected_polity_ids).order_by("long_name", "id")
+    )
+    selected_inst_type_filters = list(
+        Instability_type.objects.filter(id__in=selected_inst_type_ids).order_by(
+            "name", "id"
+        )
+    )
+    selected_ra_check_filters = list(
+        Check_choice.objects.filter(id__in=selected_ra_check_ids).order_by(
+            "name", "id"
+        )
+    )
+    instability_types = (
+        Instability_type.objects.filter(
+            Q(crisisdb_instability_events__in=inst_type_option_queryset)
+            | Q(id__in=selected_inst_type_ids)
+        )
+        .annotate(
+            event_count=Count(
+                "crisisdb_instability_events",
+                filter=Q(crisisdb_instability_events__in=inst_type_option_queryset),
+                distinct=True,
+            )
+        )
+        .distinct()
+        .order_by("name")
+    )
+    check_choices = (
+        Check_choice.objects.filter(
+            Q(crisisdb_instability_events__in=ra_check_option_queryset)
+            | Q(id__in=selected_ra_check_ids)
+        )
+        .annotate(
+            event_count=Count(
+                "crisisdb_instability_events",
+                filter=Q(crisisdb_instability_events__in=ra_check_option_queryset),
+                distinct=True,
+            )
+        )
+        .distinct()
+        .order_by("name")
+    )
     excluded_ra_check_choices = list(
         Check_choice.objects.filter(
             Q(crisisdb_instability_events__in=excluded_ra_check_option_queryset)
@@ -1229,24 +1301,17 @@ def build_instability_list_context(model_class, request):
         "unreliable_polities": Polity.objects.filter(
             unreliable_instability_events=True
         ).order_by("new_name"),
-        "instability_types": Instability_type.objects.filter(
-            crisisdb_instability_events__in=inst_type_option_queryset
-        )
-        .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
-        .distinct()
-        .order_by("name"),
-        "check_choices": Check_choice.objects.filter(
-            crisisdb_instability_events__in=ra_check_option_queryset
-        )
-        .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
-        .distinct()
-        .order_by("name"),
+        "instability_types": instability_types,
+        "check_choices": check_choices,
         "macro_events_with_counts": macro_events_with_counts,
         "macro_events": [event for event, _count in macro_events_with_counts],
         "selected_macro": selected_macro_events[0] if len(selected_macro_events) == 1 else None,
         "selected_macro_events": selected_macro_events,
         "selected_event_ids": selected_event_ids,
         "selected_event_filters": selected_event_filters,
+        "selected_polity_filters": selected_polity_filters,
+        "selected_inst_type_filters": selected_inst_type_filters,
+        "selected_ra_check_filters": selected_ra_check_filters,
         "selected_text_queries": selected_text_queries,
         "selected_is_macro_event": request.GET.get("is_macro_event"),
         "name_query": request.GET.get("searched_name", "").strip(),
@@ -1258,7 +1323,8 @@ def build_instability_list_context(model_class, request):
         "selected_batch_values": selected_batch_values,
         "batch_filter_forces_llm": batch_filter_forces_llm,
         "selected_row_quality": selected_row_quality,
-        "default_excluded_ra_check_ids": get_default_excluded_ra_check_ids(),
+        "default_invalid_filter_active": default_invalid_filter_active,
+        "default_excluded_ra_check_ids": default_excluded_ra_check_ids,
         "excluded_ra_check_choices": excluded_ra_check_choices,
         "selected_excluded_ra_check_ids": selected_excluded_ra_check_ids,
         "selected_excluded_ra_check_labels": selected_excluded_ra_check_labels,
@@ -1268,6 +1334,8 @@ def build_instability_list_context(model_class, request):
         "selected_ra_check_ids": selected_ra_check_ids,
         "selected_inst_extent_values": selected_inst_extent_values,
         "selected_inst_intensity_values": selected_inst_intensity_values,
+        "selected_year_from_min": selected_year_from_min,
+        "selected_year_to_max": selected_year_to_max,
         "active_filter_count": get_active_instability_filter_count(request),
         "selected_global_filter_tokens": build_selected_instability_filter_token_options(request),
         "source_filter_choices": source_filter_choices,

--- a/seshat/apps/crisisdb/instability_filters.py
+++ b/seshat/apps/crisisdb/instability_filters.py
@@ -1,7 +1,7 @@
 import datetime
-from collections import Counter
+from collections import Counter, defaultdict
 
-from django.db.models import F, IntegerField, Q
+from django.db.models import Count, F, IntegerField, Q
 from django.db.models.functions import Cast, Coalesce
 from django.utils.dateparse import parse_date
 from django.utils import timezone
@@ -22,6 +22,15 @@ BATCH_3_END = datetime.date(2026, 3, 1)
 BATCH_1_END_DATETIME = timezone.make_aware(datetime.datetime.combine(BATCH_1_END, datetime.time()))
 BATCH_2_END_DATETIME = timezone.make_aware(datetime.datetime.combine(BATCH_2_END, datetime.time()))
 BATCH_3_END_DATETIME = timezone.make_aware(datetime.datetime.combine(BATCH_3_END, datetime.time()))
+GOOD_ROW_FILTER = "good"
+GOOD_ROW_EXCLUDED_CHECK_NAMES = frozenset(
+    {
+        "Bad Row",
+        "Duplicate",
+        "Not Instability Event",
+        "External Event",
+    }
+)
 
 
 def get_batch_tag(created_date):
@@ -81,6 +90,35 @@ def apply_instability_batch_filter(queryset, selected_batch):
     return queryset
 
 
+def get_request_list(request, key):
+    return [value.strip() for value in request.GET.getlist(key) if value and value.strip()]
+
+
+def get_selected_row_quality(request):
+    selected_row_quality = request.GET.get("row_quality")
+    if selected_row_quality == GOOD_ROW_FILTER:
+        return selected_row_quality
+    return None
+
+
+def build_macro_event_filter_query(selected_macro_events):
+    macro_event_query = Q()
+    for macro_event in selected_macro_events:
+        desired_str = "(macro event: " + macro_event.lower()
+        macro_event_query |= Q(llm_name__icontains=desired_str) | Q(
+            name__icontains=desired_str
+        )
+    return macro_event_query
+
+
+def apply_instability_row_quality_filter(queryset, selected_row_quality):
+    if selected_row_quality == GOOD_ROW_FILTER:
+        return queryset.exclude(
+            ra_check__name__in=GOOD_ROW_EXCLUDED_CHECK_NAMES
+        ).distinct()
+    return queryset
+
+
 def get_polity_instability_queryset(polity_id, selected_source=None, selected_batch=None):
     queryset = Instability_event.objects.filter(
         polity__id=polity_id,
@@ -111,20 +149,56 @@ def apply_instability_event_source_filter(queryset, request):
     return queryset
 
 
-def apply_instability_event_filters(queryset, request):
-    year_from_min = request.GET.get("year_from_min")
-    year_to_max = request.GET.get("year_to_max")
-    created_before = request.GET.get("created_before")
-    selected_batch = request.GET.get("selected_batch")
-    selected_source = get_selected_instability_source(request)
-    polity_id = request.GET.get("polity")
-    inst_type_ids = request.GET.getlist("inst_type")
-    ra_check_ids = request.GET.getlist("ra_check")
-    inst_extent = request.GET.get("inst_extent")
-    inst_intensity = request.GET.get("inst_intensity")
-    selected_macro = request.GET.get("macro_event")
-    selected_is_macro_event = request.GET.get("is_macro_event")
-    name_query = request.GET.get("searched_name", "").strip()
+def apply_instability_event_filters(queryset, request, ignored_filters=None):
+    ignored_filters = set(ignored_filters or [])
+    year_from_min = (
+        None if "year_from_min" in ignored_filters else request.GET.get("year_from_min")
+    )
+    year_to_max = (
+        None if "year_to_max" in ignored_filters else request.GET.get("year_to_max")
+    )
+    created_before = (
+        None if "created_before" in ignored_filters else request.GET.get("created_before")
+    )
+    selected_batch = (
+        None if "selected_batch" in ignored_filters else request.GET.get("selected_batch")
+    )
+    selected_source = (
+        None if "source" in ignored_filters else get_selected_instability_source(request)
+    )
+    polity_ids = [] if "polity" in ignored_filters else get_request_list(request, "polity")
+    inst_type_ids = (
+        [] if "inst_type" in ignored_filters else get_request_list(request, "inst_type")
+    )
+    ra_check_ids = (
+        [] if "ra_check" in ignored_filters else get_request_list(request, "ra_check")
+    )
+    inst_extent_values = (
+        [] if "inst_extent" in ignored_filters else get_request_list(request, "inst_extent")
+    )
+    inst_intensity_values = (
+        []
+        if "inst_intensity" in ignored_filters
+        else get_request_list(request, "inst_intensity")
+    )
+    selected_macro_events = (
+        []
+        if "macro_event" in ignored_filters
+        else get_request_list(request, "macro_event")
+    )
+    selected_is_macro_event = (
+        None
+        if "is_macro_event" in ignored_filters
+        else request.GET.get("is_macro_event")
+    )
+    name_query = (
+        ""
+        if "searched_name" in ignored_filters
+        else request.GET.get("searched_name", "").strip()
+    )
+    selected_row_quality = (
+        None if "row_quality" in ignored_filters else get_selected_row_quality(request)
+    )
 
     if inst_type_ids:
         queryset = queryset.filter(inst_type__in=inst_type_ids).distinct()
@@ -132,28 +206,28 @@ def apply_instability_event_filters(queryset, request):
     if ra_check_ids:
         queryset = queryset.filter(ra_check__in=ra_check_ids).distinct()
 
-    if inst_extent:
-        queryset = queryset.filter(inst_extent=inst_extent)
+    if inst_extent_values:
+        queryset = queryset.filter(inst_extent__in=inst_extent_values)
 
-    if inst_intensity:
-        queryset = queryset.filter(inst_intensity=inst_intensity)
+    if inst_intensity_values:
+        queryset = queryset.filter(inst_intensity__in=inst_intensity_values)
 
-    if polity_id:
-        queryset = queryset.filter(polity__id=polity_id)
+    if polity_ids:
+        queryset = queryset.filter(polity__id__in=polity_ids)
 
-    queryset = apply_instability_event_source_filter(queryset, request)
+    if selected_source:
+        queryset = queryset.filter(source=selected_source)
 
-    if selected_macro:
-        desired_str = "(macro event: " + selected_macro.lower()
-        queryset = queryset.filter(
-            Q(llm_name__icontains=desired_str) | Q(name__icontains=desired_str)
-        )
+    if selected_macro_events:
+        queryset = queryset.filter(build_macro_event_filter_query(selected_macro_events))
 
     if selected_is_macro_event in {"true", "false"}:
         queryset = queryset.filter(is_macro_event=(selected_is_macro_event == "true"))
 
     if name_query:
         queryset = queryset.filter(name__icontains=name_query)
+
+    queryset = apply_instability_row_quality_filter(queryset, selected_row_quality)
 
     queryset = queryset.annotate(
         start_year_effective=Coalesce("year_from", F("polity__start_year")),
@@ -213,6 +287,15 @@ def get_filtered_instability_queryset(model_class, request):
     queryset = get_instability_list_queryset(model_class)
     queryset = apply_instability_event_filters(queryset, request)
     return apply_instability_event_ordering(queryset, request.GET.get("orderby"))
+
+
+def get_instability_filter_option_queryset(model_class, request, ignored_filters=None):
+    queryset = get_instability_list_queryset(model_class)
+    return apply_instability_event_filters(
+        queryset,
+        request,
+        ignored_filters=ignored_filters,
+    )
 
 
 def get_instability_checking_status(event):
@@ -276,16 +359,57 @@ def build_instability_json_coded_values(event):
 def build_instability_list_context(model_class, request):
     selected_source = get_selected_instability_source(request)
     selected_batch = request.GET.get("selected_batch")
-    filter_option_queryset = apply_instability_event_source_filter(
-        get_instability_list_queryset(model_class),
+    selected_row_quality = get_selected_row_quality(request)
+    selected_polity_ids = get_request_list(request, "polity")
+    selected_macro_events = get_request_list(request, "macro_event")
+    selected_inst_type_ids = get_request_list(request, "inst_type")
+    selected_ra_check_ids = get_request_list(request, "ra_check")
+    selected_inst_extent_values = get_request_list(request, "inst_extent")
+    selected_inst_intensity_values = get_request_list(request, "inst_intensity")
+
+    polity_option_queryset = get_instability_filter_option_queryset(
+        model_class,
         request,
+        ignored_filters={"polity"},
     )
-    polity_ids = filter_option_queryset.values_list("polity_id", flat=True).distinct()
-    polities = Polity.objects.filter(id__in=polity_ids).order_by("new_name")
+    macro_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={"macro_event"},
+    )
+    inst_type_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={"inst_type"},
+    )
+    ra_check_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={"ra_check"},
+    )
+    inst_extent_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={"inst_extent"},
+    )
+    inst_intensity_option_queryset = get_instability_filter_option_queryset(
+        model_class,
+        request,
+        ignored_filters={"inst_intensity"},
+    )
+
+    polity_counts = {
+        row["polity_id"]: row["event_count"]
+        for row in polity_option_queryset.values("polity_id").annotate(
+            event_count=Count("id", distinct=True)
+        )
+        if row["polity_id"] is not None
+    }
+    polities = list(Polity.objects.filter(id__in=polity_counts).order_by("new_name"))
 
     macro_event_list = [
         obj.made_up_macro_event
-        for obj in filter_option_queryset
+        for obj in macro_option_queryset
         if obj.made_up_macro_event
     ]
     macro_event_counts = Counter(macro_event_list)
@@ -295,43 +419,88 @@ def build_instability_list_context(model_class, request):
     )
 
     batch_order = ["Batch 1", "Batch 2", "Batch 3", "Batch 4", "Unknown"]
+    polity_batch_tags = defaultdict(set)
+    for polity_id, source, created_date in polity_option_queryset.values_list(
+        "polity_id",
+        "source",
+        "created_date",
+    ):
+        if (
+            polity_id is not None
+            and source == Instability_event.Source.LLM
+            and created_date is not None
+        ):
+            polity_batch_tags[polity_id].add(get_batch_tag(created_date))
+
     enriched_polities = []
     for polity in polities:
-        llm_created_dates = filter_option_queryset.filter(
-            polity=polity,
-            source=Instability_event.Source.LLM,
-        ).values_list("created_date", flat=True).distinct()
-
         batch_list = sorted(
-            {
-                get_batch_tag(created.date())
-                for created in llm_created_dates
-                if created is not None
-            },
+            polity_batch_tags.get(polity.id, set()),
             key=lambda value: (
                 batch_order.index(value) if value in batch_order else len(batch_order)
             ),
         )
+        setattr(polity, "event_count", polity_counts.get(polity.id, 0))
         setattr(polity, "batch_list", batch_list)
         enriched_polities.append(polity)
+
+    inst_extent_counts = {
+        row["inst_extent"]: row["event_count"]
+        for row in inst_extent_option_queryset.exclude(inst_extent__isnull=True)
+        .values("inst_extent")
+        .annotate(event_count=Count("id", distinct=True))
+    }
+    inst_intensity_counts = {
+        row["inst_intensity"]: row["event_count"]
+        for row in inst_intensity_option_queryset.exclude(inst_intensity__isnull=True)
+        .values("inst_intensity")
+        .annotate(event_count=Count("id", distinct=True))
+    }
+    inst_extent_filter_choices = [
+        (value, label, inst_extent_counts.get(value, 0))
+        for value, label in INST_EXTENT_CHOICES
+        if inst_extent_counts.get(value, 0) or value in selected_inst_extent_values
+    ]
+    inst_intensity_filter_choices = [
+        (value, label, inst_intensity_counts.get(value, 0))
+        for value, label in INST_INTENSITY_CHOICES
+        if inst_intensity_counts.get(value, 0) or value in selected_inst_intensity_values
+    ]
 
     return {
         "polities": enriched_polities,
         "unreliable_polities": Polity.objects.filter(
             unreliable_instability_events=True
         ).order_by("new_name"),
-        "instability_types": Instability_type.objects.all(),
-        "check_choices": Check_choice.objects.all(),
+        "instability_types": Instability_type.objects.filter(
+            crisisdb_instability_events__in=inst_type_option_queryset
+        )
+        .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
+        .distinct()
+        .order_by("name"),
+        "check_choices": Check_choice.objects.filter(
+            crisisdb_instability_events__in=ra_check_option_queryset
+        )
+        .annotate(event_count=Count("crisisdb_instability_events", distinct=True))
+        .distinct()
+        .order_by("name"),
         "macro_events_with_counts": macro_events_with_counts,
         "macro_events": [event for event, _count in macro_events_with_counts],
-        "selected_macro": request.GET.get("macro_event"),
+        "selected_macro": selected_macro_events[0] if len(selected_macro_events) == 1 else None,
+        "selected_macro_events": selected_macro_events,
         "selected_is_macro_event": request.GET.get("is_macro_event"),
         "name_query": request.GET.get("searched_name", "").strip(),
         "selected_source": selected_source,
         "selected_batch": selected_batch,
+        "selected_row_quality": selected_row_quality,
         "show_llm_batch_filter": selected_source != Instability_event.Source.MANUAL,
-        "selected_inst_type_ids": request.GET.getlist("inst_type"),
-        "selected_ra_check_ids": request.GET.getlist("ra_check"),
+        "selected_polity_ids": selected_polity_ids,
+        "selected_inst_type_ids": selected_inst_type_ids,
+        "selected_ra_check_ids": selected_ra_check_ids,
+        "selected_inst_extent_values": selected_inst_extent_values,
+        "selected_inst_intensity_values": selected_inst_intensity_values,
+        "inst_extent_filter_choices": inst_extent_filter_choices,
+        "inst_intensity_filter_choices": inst_intensity_filter_choices,
         "INST_EXTENT_CHOICES": INST_EXTENT_CHOICES,
         "INST_INTENSITY_CHOICES": INST_INTENSITY_CHOICES,
     }

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -71,9 +71,58 @@ class InstabilityCreateViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, reverse("instability_event-create"))
+        self.assertContains(response, "Apply filters")
+        self.assertContains(response, 'id="year_from_min"')
+        self.assertContains(response, 'id="year_to_max"')
+        self.assertNotContains(response, 'id="instability-time-section"')
         self.assertContains(response, 'data-bs-target="#instability-scope-section"')
         self.assertContains(response, 'aria-expanded="false"')
         self.assertNotContains(response, 'id="instability-scope-section" class="collapse show"')
+
+    def test_invalid_year_filters_are_ignored_without_error(self):
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"year_from_min": "not-a-year", "year_to_max": "1.5"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["selected_year_from_min"])
+        self.assertIsNone(response.context["selected_year_to_max"])
+        self.assertEqual(response.context["active_filter_count"], 0)
+
+    def test_year_zero_is_a_valid_filter_value(self):
+        polity = Polity.objects.create(
+            name="year_zero_filter_polity",
+            new_name="year_zero_filter_polity",
+            long_name="Year Zero Filter Polity",
+            start_year=-100,
+            end_year=100,
+        )
+        included_event = Instability_event.objects.create(
+            polity=polity,
+            name="Year Zero Included Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=0,
+            year_to=0,
+        )
+        Instability_event.objects.create(
+            polity=polity,
+            name="Before Year Zero Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=-10,
+            year_to=-10,
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"year_from_min": "0", "year_to_max": "0"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [included_event])
+        self.assertEqual(response.context["selected_year_from_min"], 0)
+        self.assertEqual(response.context["selected_year_to_max"], 0)
+        self.assertEqual(response.context["active_filter_count"], 2)
 
     def test_instability_row_actions_include_inline_create_button(self):
         polity = Polity.objects.create(
@@ -296,6 +345,52 @@ class InstabilityCreateViewTests(TestCase):
         )
         self.assertIsNone(response.context["selected_source"])
         self.assertEqual(response.context["active_filter_count"], 2)
+
+    def test_zero_result_filters_keep_selected_active_filter_labels(self):
+        polity = Polity.objects.create(
+            name="zero_result_filter_polity",
+            new_name="zero_result_filter_polity",
+            long_name="Zero Result Filter Polity",
+            start_year=100,
+            end_year=200,
+        )
+        check = Check_choice.objects.create(
+            name="Zero Result Check",
+            check_description="Used to verify selected filter labels.",
+            color="Red",
+        )
+        event = Instability_event.objects.create(
+            polity=polity,
+            name="Zero Result LLM Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        event.ra_check.add(check)
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {
+                "polity": str(polity.id),
+                "ra_check": str(check.id),
+                "source": Instability_event.Source.MANUAL,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [])
+        self.assertEqual(response.context["selected_polity_filters"], [polity])
+        self.assertEqual(response.context["selected_ra_check_filters"], [check])
+        self.assertEqual(
+            [option.id for option in response.context["polities"] if option.event_count == 0],
+            [polity.id],
+        )
+        self.assertEqual(
+            [option.id for option in response.context["check_choices"] if option.event_count == 0],
+            [check.id],
+        )
+        self.assertContains(response, '<small class="fw-light">Polity:</small>')
+        self.assertContains(response, '<small class="fw-light">RA Check:</small>')
 
     def test_batch_filter_forces_llm_rows_even_with_manual_source(self):
         polity = Polity.objects.create(
@@ -940,10 +1035,14 @@ class InstabilityCreateViewTests(TestCase):
             ["Bad Row", "External Event"],
         )
         self.assertEqual(response.context["active_filter_count"], 1)
+        self.assertTrue(response.context["default_invalid_filter_active"])
         self.assertContains(response, "1 filter active")
         self.assertContains(response, "Exclude invalid rows")
-        self.assertContains(response, "Invalid rows:")
-        self.assertContains(response, "Excluding Bad Row, External Event")
+        self.assertContains(response, "Include by Researcher Check")
+        self.assertContains(response, "Exclude by Researcher Check")
+        self.assertNotContains(response, "Exclude all labels")
+        self.assertContains(response, "Researcher checks excluded:")
+        self.assertContains(response, "Bad Row, External Event")
         self.assertNotContains(response, "Good rows only")
 
     def test_good_row_filter_can_customize_excluded_researcher_checks(self):
@@ -1024,7 +1123,8 @@ class InstabilityCreateViewTests(TestCase):
             response.context["selected_excluded_ra_check_labels"],
             ["Bad Row", "Intensity"],
         )
-        self.assertContains(response, "Excluding Bad Row, Intensity")
+        self.assertFalse(response.context["default_invalid_filter_active"])
+        self.assertContains(response, "Bad Row, Intensity")
         self.assertContains(response, external_event.name)
         self.assertNotContains(response, bad_row_event.name)
         self.assertNotContains(response, intensity_event.name)
@@ -1086,7 +1186,8 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(response.context["object_list"]), [clean_event, bad_row_event])
         self.assertEqual(response.context["selected_excluded_ra_check_ids"], [])
-        self.assertContains(response, "No RA labels excluded")
+        self.assertContains(response, "Researcher checks excluded:")
+        self.assertContains(response, "None")
 
     def test_polity_instability_queryset_filters_by_batch(self):
         polity = Polity.objects.create(

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -8,7 +8,10 @@ from django.utils import timezone
 
 from seshat.apps.accounts.models import Seshat_Expert
 from seshat.apps.core.models import Polity, SeshatComment
-from seshat.apps.crisisdb.instability_filters import get_polity_instability_queryset
+from seshat.apps.crisisdb.instability_filters import (
+    GOOD_ROW_FILTER,
+    get_polity_instability_queryset,
+)
 from seshat.apps.crisisdb.models import (
     Check_choice,
     Instability_event,
@@ -262,6 +265,141 @@ class InstabilityCreateViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(response.context["object_list"]), [manual_event])
+
+    def test_instability_list_can_filter_multiple_polities(self):
+        first_polity = Polity.objects.create(
+            name="multi_polity_one",
+            new_name="multi_polity_one",
+            long_name="Multi Polity One",
+            start_year=100,
+            end_year=200,
+        )
+        second_polity = Polity.objects.create(
+            name="multi_polity_two",
+            new_name="multi_polity_two",
+            long_name="Multi Polity Two",
+            start_year=100,
+            end_year=200,
+        )
+        third_polity = Polity.objects.create(
+            name="multi_polity_three",
+            new_name="multi_polity_three",
+            long_name="Multi Polity Three",
+            start_year=100,
+            end_year=200,
+        )
+        first_event = Instability_event.objects.create(
+            polity=first_polity,
+            name="First Multi Polity Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        second_event = Instability_event.objects.create(
+            polity=second_polity,
+            name="Second Multi Polity Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        Instability_event.objects.create(
+            polity=third_polity,
+            name="Third Multi Polity Event",
+            source=Instability_event.Source.LLM,
+            year_from=154,
+            year_to=155,
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"polity": [str(first_polity.id), str(second_polity.id)]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [first_event, second_event])
+        self.assertEqual(
+            response.context["selected_polity_ids"],
+            [str(first_polity.id), str(second_polity.id)],
+        )
+
+    def test_good_row_filter_excludes_only_disqualifying_checks(self):
+        polity = Polity.objects.create(
+            name="good_row_polity",
+            new_name="good_row_polity",
+            long_name="Good Row Polity",
+            start_year=100,
+            end_year=200,
+        )
+        bad_row_check = Check_choice.objects.create(
+            name="Bad Row",
+            check_description="Entire row is invalid.",
+            color="Red",
+        )
+        external_event_check = Check_choice.objects.create(
+            name="External Event",
+            check_description="External event should be excluded.",
+            color="Blue",
+        )
+        corrected_check = Check_choice.objects.create(
+            name="Intensity",
+            check_description="Intensity was corrected.",
+            color="Red",
+        )
+
+        clean_event = Instability_event.objects.create(
+            polity=polity,
+            name="Clean Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        corrected_event = Instability_event.objects.create(
+            polity=polity,
+            name="Corrected Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        corrected_event.ra_check.add(corrected_check)
+
+        excluded_bad_row_event = Instability_event.objects.create(
+            polity=polity,
+            name="Bad Row Event",
+            source=Instability_event.Source.LLM,
+            year_from=154,
+            year_to=155,
+        )
+        excluded_bad_row_event.ra_check.add(bad_row_check)
+
+        excluded_external_event = Instability_event.objects.create(
+            polity=polity,
+            name="External Event Row",
+            source=Instability_event.Source.LLM,
+            year_from=156,
+            year_to=157,
+        )
+        excluded_external_event.ra_check.add(external_event_check)
+
+        mixed_event = Instability_event.objects.create(
+            polity=polity,
+            name="Mixed Check Event",
+            source=Instability_event.Source.LLM,
+            year_from=158,
+            year_to=159,
+        )
+        mixed_event.ra_check.add(corrected_check, bad_row_check)
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"row_quality": GOOD_ROW_FILTER},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            list(response.context["object_list"]),
+            [clean_event, corrected_event],
+        )
+        self.assertEqual(response.context["selected_row_quality"], GOOD_ROW_FILTER)
 
     def test_polity_instability_queryset_filters_by_batch(self):
         polity = Polity.objects.create(

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -367,10 +367,196 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(response.context["selected_batch_values"], ["Batch 1", "Batch 4"])
         self.assertEqual(response.context["active_filter_count"], 3)
         self.assertContains(response, "3 filters active")
-        self.assertContains(response, "LLM batches")
-        self.assertContains(response, "Search events")
-        self.assertContains(response, "Search event names")
+        self.assertContains(response, "Search & add filters")
+        self.assertContains(response, "selected_batch:Batch 1")
+        self.assertContains(response, "selected_batch:Batch 4")
         self.assertNotContains(response, batch_two_event.name)
+
+    def test_instability_list_can_filter_by_exact_event_id(self):
+        polity = Polity.objects.create(
+            name="event_token_polity",
+            new_name="event_token_polity",
+            long_name="Event Token Polity",
+            start_year=100,
+            end_year=200,
+        )
+        selected_event = Instability_event.objects.create(
+            polity=polity,
+            name="Selected Exact Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=150,
+            year_to=151,
+        )
+        other_event = Instability_event.objects.create(
+            polity=polity,
+            name="Other Exact Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=152,
+            year_to=153,
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"event": str(selected_event.id)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [selected_event])
+        self.assertEqual(response.context["selected_event_ids"], [str(selected_event.id)])
+        self.assertContains(response, f"event:{selected_event.id}")
+        self.assertContains(response, "Event:")
+        self.assertNotContains(response, other_event.name)
+
+    def test_instability_list_global_text_filter_searches_across_fields(self):
+        polity = Polity.objects.create(
+            name="global_text_polity",
+            new_name="global_text_polity",
+            long_name="Global Search Polity",
+            start_year=100,
+            end_year=200,
+        )
+        event_type = Instability_type.objects.create(name="Global Search Type")
+        matching_event = Instability_event.objects.create(
+            polity=polity,
+            name="Plain Event Name",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        matching_event.inst_type.add(event_type)
+        other_event = Instability_event.objects.create(
+            polity=polity,
+            name="Other Plain Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"q": "Global Search Type"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [matching_event])
+        self.assertEqual(response.context["selected_text_queries"], ["Global Search Type"])
+        self.assertContains(response, 'text:Global Search Type')
+        self.assertContains(response, "Search:")
+        self.assertNotContains(response, other_event.name)
+
+    def test_instability_filter_token_endpoint_returns_grouped_limited_results(self):
+        polity = Polity.objects.create(
+            name="token_polity",
+            new_name="token_polity",
+            long_name="Token Polity",
+            start_year=100,
+            end_year=200,
+        )
+        event_type = Instability_type.objects.create(name="Token Rebellion")
+        check = Check_choice.objects.create(
+            name="Token Check",
+            check_description="Tokenized review label.",
+            color="Blue",
+        )
+        macro_event = Instability_event.objects.create(
+            polity=polity,
+            name="A Token Macro Event",
+            llm_name="A Token Macro Event (Macro Event: Token Umbrella)",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        macro_event.inst_type.add(event_type)
+        macro_event.ra_check.add(check)
+
+        for index in range(10):
+            Instability_event.objects.create(
+                polity=polity,
+                name=f"Token Event {index}",
+                source=Instability_event.Source.LLM,
+                year_from=152 + index,
+                year_to=153 + index,
+            )
+
+        response = self.client.get(
+            reverse("instability_event-filter-tokens"),
+            {"q": "Token"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        groups = {
+            group["text"]: group["children"]
+            for group in response.json()["results"]
+        }
+        self.assertIn("Text Search", groups)
+        self.assertIn("Polities", groups)
+        self.assertIn("Events", groups)
+        self.assertIn("Umbrella Events", groups)
+        self.assertIn("Event Types", groups)
+        self.assertIn("Researcher Checks", groups)
+        self.assertLessEqual(len(groups["Events"]), 8)
+        self.assertTrue(
+            any(option["id"] == f"polity:{polity.id}" for option in groups["Polities"])
+        )
+        self.assertTrue(
+            any(option["id"] == f"event:{macro_event.id}" for option in groups["Events"])
+        )
+        self.assertTrue(
+            any(option["id"] == "macro_event:Token Umbrella" for option in groups["Umbrella Events"])
+        )
+        self.assertTrue(
+            any(option["id"] == f"inst_type:{event_type.id}" for option in groups["Event Types"])
+        )
+        self.assertTrue(
+            any(option["id"] == f"ra_check:{check.id}" for option in groups["Researcher Checks"])
+        )
+
+    def test_instability_filter_token_endpoint_returns_source_and_batch_tokens(self):
+        polity = Polity.objects.create(
+            name="batch_token_polity",
+            new_name="batch_token_polity",
+            long_name="Batch Token Polity",
+            start_year=100,
+            end_year=200,
+        )
+        batch_one_event = Instability_event.objects.create(
+            polity=polity,
+            name="Batch Token Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        Instability_event.objects.filter(pk=batch_one_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2025, 3, 1))
+        )
+
+        batch_response = self.client.get(
+            reverse("instability_event-filter-tokens"),
+            {"q": "batch"},
+        )
+        source_response = self.client.get(
+            reverse("instability_event-filter-tokens"),
+            {"q": "llm"},
+        )
+
+        batch_groups = {
+            group["text"]: group["children"]
+            for group in batch_response.json()["results"]
+        }
+        source_groups = {
+            group["text"]: group["children"]
+            for group in source_response.json()["results"]
+        }
+        self.assertEqual(batch_response.status_code, 200)
+        self.assertIn("LLM Batches", batch_groups)
+        self.assertTrue(
+            any(option["id"] == "selected_batch:Batch 1" for option in batch_groups["LLM Batches"])
+        )
+        self.assertEqual(source_response.status_code, 200)
+        self.assertIn("Sources", source_groups)
+        self.assertTrue(
+            any(option["id"] == "source:llm" for option in source_groups["Sources"])
+        )
 
     def test_instability_list_can_filter_multiple_polities(self):
         first_polity = Polity.objects.create(
@@ -508,11 +694,162 @@ class InstabilityCreateViewTests(TestCase):
             [clean_event, corrected_event],
         )
         self.assertEqual(response.context["selected_row_quality"], GOOD_ROW_FILTER)
+        self.assertEqual(
+            response.context["selected_excluded_ra_check_ids"],
+            [str(bad_row_check.id), str(external_event_check.id)],
+        )
+        self.assertEqual(
+            response.context["selected_excluded_ra_check_labels"],
+            ["Bad Row", "External Event"],
+        )
         self.assertEqual(response.context["active_filter_count"], 1)
         self.assertContains(response, "1 filter active")
         self.assertContains(response, "Exclude invalid rows")
         self.assertContains(response, "Invalid rows:")
+        self.assertContains(response, "Excluding Bad Row, External Event")
         self.assertNotContains(response, "Good rows only")
+
+    def test_good_row_filter_can_customize_excluded_researcher_checks(self):
+        polity = Polity.objects.create(
+            name="custom_good_row_polity",
+            new_name="custom_good_row_polity",
+            long_name="Custom Good Row Polity",
+            start_year=100,
+            end_year=200,
+        )
+        bad_row_check = Check_choice.objects.create(
+            name="Bad Row",
+            check_description="Entire row is invalid.",
+            color="Red",
+        )
+        external_event_check = Check_choice.objects.create(
+            name="External Event",
+            check_description="External event should be excluded by default.",
+            color="Blue",
+        )
+        intensity_check = Check_choice.objects.create(
+            name="Intensity",
+            check_description="Intensity was corrected.",
+            color="Red",
+        )
+
+        clean_event = Instability_event.objects.create(
+            polity=polity,
+            name="Custom Clean Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        bad_row_event = Instability_event.objects.create(
+            polity=polity,
+            name="Custom Bad Row Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        bad_row_event.ra_check.add(bad_row_check)
+        external_event = Instability_event.objects.create(
+            polity=polity,
+            name="Custom External Event",
+            source=Instability_event.Source.LLM,
+            year_from=154,
+            year_to=155,
+        )
+        external_event.ra_check.add(external_event_check)
+        intensity_event = Instability_event.objects.create(
+            polity=polity,
+            name="Custom Intensity Event",
+            source=Instability_event.Source.LLM,
+            year_from=156,
+            year_to=157,
+        )
+        intensity_event.ra_check.add(intensity_check)
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {
+                "row_quality": GOOD_ROW_FILTER,
+                "excluded_ra_check_mode": "custom",
+                "excluded_ra_check": [str(bad_row_check.id), str(intensity_check.id)],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            list(response.context["object_list"]),
+            [clean_event, external_event],
+        )
+        self.assertEqual(
+            response.context["selected_excluded_ra_check_ids"],
+            [str(bad_row_check.id), str(intensity_check.id)],
+        )
+        self.assertEqual(
+            response.context["selected_excluded_ra_check_labels"],
+            ["Bad Row", "Intensity"],
+        )
+        self.assertContains(response, "Excluding Bad Row, Intensity")
+        self.assertContains(response, external_event.name)
+        self.assertNotContains(response, bad_row_event.name)
+        self.assertNotContains(response, intensity_event.name)
+
+        implied_row_quality_response = self.client.get(
+            reverse("instability_events_all"),
+            {
+                "excluded_ra_check": [str(bad_row_check.id), str(intensity_check.id)],
+            },
+        )
+
+        self.assertEqual(implied_row_quality_response.status_code, 200)
+        self.assertEqual(
+            list(implied_row_quality_response.context["object_list"]),
+            [clean_event, external_event],
+        )
+        self.assertEqual(
+            implied_row_quality_response.context["selected_row_quality"],
+            GOOD_ROW_FILTER,
+        )
+
+    def test_good_row_filter_custom_empty_excludes_no_researcher_checks(self):
+        polity = Polity.objects.create(
+            name="empty_custom_good_row_polity",
+            new_name="empty_custom_good_row_polity",
+            long_name="Empty Custom Good Row Polity",
+            start_year=100,
+            end_year=200,
+        )
+        bad_row_check = Check_choice.objects.create(
+            name="Bad Row",
+            check_description="Entire row is invalid.",
+            color="Red",
+        )
+        clean_event = Instability_event.objects.create(
+            polity=polity,
+            name="Empty Custom Clean Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        bad_row_event = Instability_event.objects.create(
+            polity=polity,
+            name="Empty Custom Bad Row Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        bad_row_event.ra_check.add(bad_row_check)
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {
+                "row_quality": GOOD_ROW_FILTER,
+                "excluded_ra_check_mode": "custom",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [clean_event, bad_row_event])
+        self.assertEqual(response.context["selected_excluded_ra_check_ids"], [])
+        self.assertContains(response, "No RA labels excluded")
 
     def test_polity_instability_queryset_filters_by_batch(self):
         polity = Polity.objects.create(
@@ -705,6 +1042,25 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(response.context["object_list"]), [macro_event])
         self.assertEqual(response.context["selected_is_macro_event"], "true")
+        self.assertContains(response, "is_macro_event:true")
+
+        token_response = self.client.get(
+            reverse("instability_event-filter-tokens"),
+            {"q": "macro"},
+        )
+        token_groups = {
+            group["text"]: group["children"]
+            for group in token_response.json()["results"]
+        }
+
+        self.assertEqual(token_response.status_code, 200)
+        self.assertIn("Macroevent Record", token_groups)
+        self.assertTrue(
+            any(
+                option["id"] == "is_macro_event:true"
+                for option in token_groups["Macroevent Record"]
+            )
+        )
 
     def test_instability_analytics_only_includes_llm_events(self):
         polity = Polity.objects.create(

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -52,10 +52,28 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(response.context["extra_var5"].name, "is_macro_event")
 
     def test_instability_list_page_shows_create_button_for_editors(self):
+        polity = Polity.objects.create(
+            name="filter_default_polity",
+            new_name="filter_default_polity",
+            long_name="Filter Default Polity",
+            start_year=100,
+            end_year=200,
+        )
+        Instability_event.objects.create(
+            polity=polity,
+            name="Filter Default Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=150,
+            year_to=151,
+        )
+
         response = self.client.get(reverse("instability_events_all"))
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, reverse("instability_event-create"))
+        self.assertContains(response, 'data-bs-target="#instability-scope-section"')
+        self.assertContains(response, 'aria-expanded="false"')
+        self.assertNotContains(response, 'id="instability-scope-section" class="collapse show"')
 
     def test_instability_row_actions_include_inline_create_button(self):
         polity = Polity.objects.create(
@@ -313,9 +331,12 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(response.context["object_list"]), [llm_event])
         self.assertEqual(response.context["selected_source_values"], [Instability_event.Source.LLM])
+        self.assertEqual(response.context["explicit_selected_source"], Instability_event.Source.MANUAL)
         self.assertEqual(response.context["selected_batch_values"], ["Batch 1"])
         self.assertTrue(response.context["batch_filter_forces_llm"])
         self.assertContains(response, "LLM only")
+        self.assertContains(response, 'data-instability-source-conflict="batch"')
+        self.assertNotContains(response, 'data-instability-clear-sources="true"')
         self.assertNotContains(response, manual_event.name)
 
     def test_instability_list_can_filter_multiple_batches(self):
@@ -370,6 +391,8 @@ class InstabilityCreateViewTests(TestCase):
         self.assertContains(response, "Search & add filters")
         self.assertContains(response, "selected_batch:Batch 1")
         self.assertContains(response, "selected_batch:Batch 4")
+        self.assertContains(response, 'data-instability-source-conflict="batch"')
+        self.assertNotContains(response, 'data-instability-clear-sources="true"')
         self.assertNotContains(response, batch_two_event.name)
 
     def test_instability_list_can_filter_by_exact_event_id(self):
@@ -444,6 +467,22 @@ class InstabilityCreateViewTests(TestCase):
         self.assertContains(response, "Search:")
         self.assertNotContains(response, other_event.name)
 
+        reordered_response = self.client.get(
+            reverse("instability_events_all"),
+            {"q": "TYPE global"},
+        )
+
+        self.assertEqual(reordered_response.status_code, 200)
+        self.assertEqual(list(reordered_response.context["object_list"]), [matching_event])
+
+        punctuation_response = self.client.get(
+            reverse("instability_events_all"),
+            {"q": "!!!"},
+        )
+
+        self.assertEqual(punctuation_response.status_code, 200)
+        self.assertEqual(list(punctuation_response.context["object_list"]), [])
+
     def test_instability_filter_token_endpoint_returns_grouped_limited_results(self):
         polity = Polity.objects.create(
             name="token_polity",
@@ -484,10 +523,22 @@ class InstabilityCreateViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        group_names = [group["text"] for group in response.json()["results"]]
         groups = {
             group["text"]: group["children"]
             for group in response.json()["results"]
         }
+        self.assertEqual(
+            group_names,
+            [
+                "Polities",
+                "Event Types",
+                "Researcher Checks",
+                "Text Search",
+                "Events",
+                "Umbrella Events",
+            ],
+        )
         self.assertIn("Text Search", groups)
         self.assertIn("Polities", groups)
         self.assertIn("Events", groups)
@@ -509,6 +560,31 @@ class InstabilityCreateViewTests(TestCase):
         )
         self.assertTrue(
             any(option["id"] == f"ra_check:{check.id}" for option in groups["Researcher Checks"])
+        )
+
+        reordered_response = self.client.get(
+            reverse("instability_event-filter-tokens"),
+            {"q": "REBELLION token"},
+        )
+        reordered_groups = {
+            group["text"]: group["children"]
+            for group in reordered_response.json()["results"]
+        }
+
+        self.assertEqual(reordered_response.status_code, 200)
+        reordered_group_names = [
+            group["text"]
+            for group in reordered_response.json()["results"]
+        ]
+        self.assertLess(
+            reordered_group_names.index("Event Types"),
+            reordered_group_names.index("Text Search"),
+        )
+        self.assertTrue(
+            any(
+                option["id"] == f"inst_type:{event_type.id}"
+                for option in reordered_groups["Event Types"]
+            )
         )
 
     def test_instability_filter_token_endpoint_returns_source_and_batch_tokens(self):
@@ -557,6 +633,167 @@ class InstabilityCreateViewTests(TestCase):
         self.assertTrue(
             any(option["id"] == "source:llm" for option in source_groups["Sources"])
         )
+
+    def test_instability_list_can_require_researcher_checks(self):
+        polity = Polity.objects.create(
+            name="require_check_polity",
+            new_name="require_check_polity",
+            long_name="Require Check Polity",
+            start_year=100,
+            end_year=200,
+        )
+        required_check = Check_choice.objects.create(
+            name="Require Check",
+            check_description="A check used for positive filtering.",
+            color="Blue",
+        )
+        other_check = Check_choice.objects.create(
+            name="Other Check",
+            check_description="A different review label.",
+            color="Red",
+        )
+        matching_event = Instability_event.objects.create(
+            polity=polity,
+            name="Matching Checked Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        matching_event.ra_check.add(required_check)
+        non_matching_event = Instability_event.objects.create(
+            polity=polity,
+            name="Other Checked Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        non_matching_event.ra_check.add(other_check)
+        unchecked_event = Instability_event.objects.create(
+            polity=polity,
+            name="Unchecked Event",
+            source=Instability_event.Source.LLM,
+            year_from=154,
+            year_to=155,
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"ra_check": str(required_check.id)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [matching_event])
+        self.assertEqual(response.context["selected_ra_check_ids"], [str(required_check.id)])
+        self.assertContains(response, matching_event.name)
+        self.assertNotContains(response, non_matching_event.name)
+        self.assertNotContains(response, unchecked_event.name)
+
+    def test_required_researcher_checks_are_not_also_excluded(self):
+        polity = Polity.objects.create(
+            name="require_exclude_conflict_polity",
+            new_name="require_exclude_conflict_polity",
+            long_name="Require Exclude Conflict Polity",
+            start_year=100,
+            end_year=200,
+        )
+        required_check = Check_choice.objects.create(
+            name="Required Conflict Check",
+            check_description="The check that should stay required.",
+            color="Blue",
+        )
+        other_excluded_check = Check_choice.objects.create(
+            name="Other Excluded Check",
+            check_description="A separate excluded label.",
+            color="Red",
+        )
+        matching_event = Instability_event.objects.create(
+            polity=polity,
+            name="Required Conflict Matching Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        matching_event.ra_check.add(required_check)
+        Instability_event.objects.create(
+            polity=polity,
+            name="Required Conflict Unchecked Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {
+                "ra_check": str(required_check.id),
+                "row_quality": GOOD_ROW_FILTER,
+                "excluded_ra_check_mode": "custom",
+                "excluded_ra_check": [
+                    str(required_check.id),
+                    str(other_excluded_check.id),
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [matching_event])
+        self.assertEqual(response.context["selected_ra_check_ids"], [str(required_check.id)])
+        self.assertEqual(
+            response.context["selected_excluded_ra_check_ids"],
+            [str(other_excluded_check.id)],
+        )
+
+    def test_required_default_invalid_check_is_not_excluded(self):
+        polity = Polity.objects.create(
+            name="require_default_invalid_polity",
+            new_name="require_default_invalid_polity",
+            long_name="Require Default Invalid Polity",
+            start_year=100,
+            end_year=200,
+        )
+        bad_row_check = Check_choice.objects.create(
+            name="Bad Row",
+            check_description="Default invalid label that is explicitly required.",
+            color="Red",
+        )
+        external_event_check = Check_choice.objects.create(
+            name="External Event",
+            check_description="Another default invalid label.",
+            color="Blue",
+        )
+        bad_row_event = Instability_event.objects.create(
+            polity=polity,
+            name="Required Bad Row Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        bad_row_event.ra_check.add(bad_row_check)
+        external_event = Instability_event.objects.create(
+            polity=polity,
+            name="Default External Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        external_event.ra_check.add(external_event_check)
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {
+                "ra_check": str(bad_row_check.id),
+                "row_quality": GOOD_ROW_FILTER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [bad_row_event])
+        self.assertEqual(response.context["selected_ra_check_ids"], [str(bad_row_check.id)])
+        self.assertEqual(
+            response.context["selected_excluded_ra_check_ids"],
+            [str(external_event_check.id)],
+        )
+        self.assertNotContains(response, external_event.name)
 
     def test_instability_list_can_filter_multiple_polities(self):
         first_polity = Polity.objects.create(
@@ -1043,6 +1280,9 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(list(response.context["object_list"]), [macro_event])
         self.assertEqual(response.context["selected_is_macro_event"], "true")
         self.assertContains(response, "is_macro_event:true")
+        self.assertContains(response, "Macroevent")
+        self.assertContains(response, "Macro events")
+        self.assertContains(response, "Normal events")
 
         token_response = self.client.get(
             reverse("instability_event-filter-tokens"),
@@ -1054,11 +1294,50 @@ class InstabilityCreateViewTests(TestCase):
         }
 
         self.assertEqual(token_response.status_code, 200)
-        self.assertIn("Macroevent Record", token_groups)
+        self.assertIn("Macroevent", token_groups)
         self.assertTrue(
             any(
                 option["id"] == "is_macro_event:true"
-                for option in token_groups["Macroevent Record"]
+                for option in token_groups["Macroevent"]
+            )
+        )
+
+        true_token_response = self.client.get(
+            reverse("instability_event-filter-tokens"),
+            {"q": "true"},
+        )
+        true_group_names = [
+            group["text"]
+            for group in true_token_response.json()["results"]
+        ]
+        true_token_groups = {
+            group["text"]: group["children"]
+            for group in true_token_response.json()["results"]
+        }
+
+        self.assertEqual(true_token_response.status_code, 200)
+        self.assertEqual(true_group_names[0], "Macroevent")
+        self.assertTrue(
+            any(
+                option["id"] == "is_macro_event:true"
+                for option in true_token_groups["Macroevent"]
+            )
+        )
+
+        false_token_response = self.client.get(
+            reverse("instability_event-filter-tokens"),
+            {"q": "false"},
+        )
+        false_token_groups = {
+            group["text"]: group["children"]
+            for group in false_token_response.json()["results"]
+        }
+
+        self.assertEqual(false_token_response.status_code, 200)
+        self.assertTrue(
+            any(
+                option["id"] == "is_macro_event:false"
+                for option in false_token_groups["Macroevent"]
             )
         )
 

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -242,7 +242,44 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(response.context["object_list"]), [manual_event])
 
-    def test_batch_filter_is_ignored_for_manual_source(self):
+    def test_instability_list_can_filter_multiple_sources(self):
+        polity = Polity.objects.create(
+            name="multi_source_filter_polity",
+            new_name="multi_source_filter_polity",
+            long_name="Multi Source Filter Polity",
+            start_year=100,
+            end_year=200,
+        )
+        manual_event = Instability_event.objects.create(
+            polity=polity,
+            name="Manual Multi Source Event",
+            source=Instability_event.Source.MANUAL,
+            year_from=150,
+            year_to=151,
+        )
+        llm_event = Instability_event.objects.create(
+            polity=polity,
+            name="LLM Multi Source Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"source": [Instability_event.Source.MANUAL, Instability_event.Source.LLM]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [manual_event, llm_event])
+        self.assertEqual(
+            response.context["selected_source_values"],
+            [Instability_event.Source.MANUAL, Instability_event.Source.LLM],
+        )
+        self.assertIsNone(response.context["selected_source"])
+        self.assertEqual(response.context["active_filter_count"], 2)
+
+    def test_batch_filter_forces_llm_rows_even_with_manual_source(self):
         polity = Polity.objects.create(
             name="manual_batch_polity",
             new_name="manual_batch_polity",
@@ -257,6 +294,16 @@ class InstabilityCreateViewTests(TestCase):
             year_from=150,
             year_to=151,
         )
+        llm_event = Instability_event.objects.create(
+            polity=polity,
+            name="LLM Batch Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        Instability_event.objects.filter(pk=llm_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2025, 3, 1))
+        )
 
         response = self.client.get(
             reverse("instability_events_all"),
@@ -264,7 +311,66 @@ class InstabilityCreateViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.context["object_list"]), [manual_event])
+        self.assertEqual(list(response.context["object_list"]), [llm_event])
+        self.assertEqual(response.context["selected_source_values"], [Instability_event.Source.LLM])
+        self.assertEqual(response.context["selected_batch_values"], ["Batch 1"])
+        self.assertTrue(response.context["batch_filter_forces_llm"])
+        self.assertContains(response, "LLM only")
+        self.assertNotContains(response, manual_event.name)
+
+    def test_instability_list_can_filter_multiple_batches(self):
+        polity = Polity.objects.create(
+            name="multi_batch_polity",
+            new_name="multi_batch_polity",
+            long_name="Multi Batch Polity",
+            start_year=100,
+            end_year=200,
+        )
+        batch_one_event = Instability_event.objects.create(
+            polity=polity,
+            name="Batch One List Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        batch_four_event = Instability_event.objects.create(
+            polity=polity,
+            name="Batch Four List Event",
+            source=Instability_event.Source.LLM,
+            year_from=152,
+            year_to=153,
+        )
+        batch_two_event = Instability_event.objects.create(
+            polity=polity,
+            name="Batch Two List Event",
+            source=Instability_event.Source.LLM,
+            year_from=154,
+            year_to=155,
+        )
+        Instability_event.objects.filter(pk=batch_one_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2025, 3, 1))
+        )
+        Instability_event.objects.filter(pk=batch_four_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2026, 3, 2))
+        )
+        Instability_event.objects.filter(pk=batch_two_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2025, 4, 1))
+        )
+
+        response = self.client.get(
+            reverse("instability_events_all"),
+            {"selected_batch": ["Batch 1", "Batch 4"]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["object_list"]), [batch_one_event, batch_four_event])
+        self.assertEqual(response.context["selected_batch_values"], ["Batch 1", "Batch 4"])
+        self.assertEqual(response.context["active_filter_count"], 3)
+        self.assertContains(response, "3 filters active")
+        self.assertContains(response, "LLM batches")
+        self.assertContains(response, "Search events")
+        self.assertContains(response, "Search event names")
+        self.assertNotContains(response, batch_two_event.name)
 
     def test_instability_list_can_filter_multiple_polities(self):
         first_polity = Polity.objects.create(
@@ -321,6 +427,8 @@ class InstabilityCreateViewTests(TestCase):
             response.context["selected_polity_ids"],
             [str(first_polity.id), str(second_polity.id)],
         )
+        self.assertEqual(response.context["active_filter_count"], 2)
+        self.assertContains(response, "2 filters active")
 
     def test_good_row_filter_excludes_only_disqualifying_checks(self):
         polity = Polity.objects.create(
@@ -400,6 +508,11 @@ class InstabilityCreateViewTests(TestCase):
             [clean_event, corrected_event],
         )
         self.assertEqual(response.context["selected_row_quality"], GOOD_ROW_FILTER)
+        self.assertEqual(response.context["active_filter_count"], 1)
+        self.assertContains(response, "1 filter active")
+        self.assertContains(response, "Exclude invalid rows")
+        self.assertContains(response, "Invalid rows:")
+        self.assertNotContains(response, "Good rows only")
 
     def test_polity_instability_queryset_filters_by_batch(self):
         polity = Polity.objects.create(

--- a/seshat/apps/crisisdb/urls.py
+++ b/seshat/apps/crisisdb/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
     path('playgrounddownload/', views.playgrounddownload,
          name="playgrounddownload"),
      path("analytics-instability/", views.instability_analytics, name="instability-analytics"),
+     path(
+          "instability_event/filter_tokens/",
+          views.instability_filter_tokens,
+          name="instability_event-filter-tokens",
+     ),
 
      #path('fpl_all/', views.fpl_all,name="fpl_all"), 
 ]
@@ -293,7 +298,6 @@ urlpatterns += [
     path('external_conflictmetadownload/', views.external_conflict_meta_download,
          name="external_conflict-metadownload"),
 ]
-        
 
 urlpatterns += [
     path('internal_conflict/create/', views.Internal_conflictCreate.as_view(),
@@ -312,7 +316,6 @@ urlpatterns += [
     path('internal_conflictmetadownload/', views.internal_conflict_meta_download,
          name="internal_conflict-metadownload"),
 ]
-        
 
 urlpatterns += [
     path('external_conflict_side/create/', views.External_conflict_sideCreate.as_view(),
@@ -331,7 +334,6 @@ urlpatterns += [
     path('external_conflict_sidemetadownload/', views.external_conflict_side_meta_download,
          name="external_conflict_side-metadownload"),
 ]
-        
 
 urlpatterns += [
     path('agricultural_population/create/', views.Agricultural_populationCreate.as_view(),
@@ -654,4 +656,3 @@ urlpatterns += [
     path('disease_outbreakmetadownload/', views.disease_outbreak_meta_download,
          name="disease_outbreak-metadownload"),
 ]
-        

--- a/seshat/apps/crisisdb/views.py
+++ b/seshat/apps/crisisdb/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMix
 from django.contrib.auth.decorators import login_required, permission_required
 from django.utils.safestring import mark_safe
 from django.views.generic.list import ListView
+from django.views.decorators.http import require_GET
 
 from django.contrib.contenttypes.models import ContentType
 
@@ -55,7 +56,11 @@ from .models import Power_transition, Crisis_consequence, Human_sacrifice, Exter
 
 
 from .forms import Power_transitionForm, Crisis_consequenceForm, Human_sacrificeForm, External_conflictForm, Internal_conflictForm, External_conflict_sideForm, Agricultural_populationForm, Arable_landForm, Arable_land_per_farmerForm, Gross_grain_shared_per_agricultural_populationForm, Net_grain_shared_per_agricultural_populationForm, SurplusForm, Military_expenseForm, Silver_inflowForm, Silver_stockForm, Total_populationForm, Gdp_per_capitaForm, Drought_eventForm, Locust_eventForm, Socioeconomic_turmoil_eventForm, Crop_failure_eventForm, Famine_eventForm, Disease_outbreakForm, Us_locationForm, Us_violence_subtypeForm, Us_violence_data_sourceForm, Us_violenceForm, CheckChoiceForm
-from .instability_filters import apply_instability_batch_filter, get_batch_tag
+from .instability_filters import (
+    apply_instability_batch_filter,
+    build_instability_filter_token_response,
+    get_batch_tag,
+)
 
 
 # Create View
@@ -106,6 +111,14 @@ def get_citations_dropdown(request):
 
     # return dropdown template as JSON response
     return JsonResponse({'data': citations_list})
+
+
+@login_required
+@require_GET
+def instability_filter_tokens(request):
+    search_query = request.GET.get("q") or request.GET.get("term") or ""
+    return JsonResponse(build_instability_filter_token_response(search_query))
+
 
 class Crisis_consequenceCreate(PermissionRequiredMixin, PolityIdMixin, CreateView):
     """


### PR DESCRIPTION
## Summary

Redesigns the instability event filters to make them more compact, intuitive, and flexible.

## Changes

- Added reusable multi-select filtering for polities, events, sources, batches, event types, researcher checks, intensity, and extent.
- Added asynchronous global search without preloading all instability events.
- Introduced collapsible filter sections and a responsive active-filter summary.
- Added explicit include/exclude researcher-check filtering.
- Added the “Exclude invalid rows” preset for the default invalid labels.
- Added reusable filter-token utilities for future variable-page filters.

## Validation

- Ran all 32 focused instability filter tests successfully.
- Verified the filter directly on desktop and mobile layouts.
- Tested multi-selection, quick filters, zero-result states, global search, and chip removal.
- `git diff --check` passes.
- No database migrations are required.