### PR TITLE
Store instability import batches explicitly

### DIFF
--- a/seshat/apps/core/management/commands/import_instability_events_csv.py
+++ b/seshat/apps/core/management/commands/import_instability_events_csv.py
@@ -102,6 +102,11 @@ class Command(BaseCommand):
         parser.add_argument("--csv", required=True, help="Absolute or relative path to the CSV file.")
         parser.add_argument("--polity", required=True, help="Polity.new_name to attach to every imported event.")
         parser.add_argument(
+            "--batch",
+            default=None,
+            help='Optional explicit LLM import batch label, for example "Batch 5".',
+        )
+        parser.add_argument(
             "--limit",
             type=int,
             default=None,
@@ -119,8 +124,12 @@ class Command(BaseCommand):
             raise CommandError(f"CSV file not found: {csv_path}")
 
         polity_name = options["polity"]
+        import_batch = (options["batch"] or "").strip() or None
         limit = options["limit"]
         dry_run = options["dry_run"]
+
+        if import_batch and len(import_batch) > 50:
+            raise CommandError("--batch must be 50 characters or fewer.")
 
         try:
             polity = Polity.objects.get(new_name=polity_name)
@@ -204,6 +213,7 @@ class Command(BaseCommand):
                     event = Instability_event.objects.create(
                         name=name,
                         source=Instability_event.Source.LLM,
+                        llm_import_batch=import_batch,
                         llm_name=llm_name,
                         polity=polity,
                         year_from=year_from,
@@ -248,4 +258,6 @@ class Command(BaseCommand):
             f"Finished CSV import for polity '{polity_name}'. "
             f"Created: {created_count}."
         )
+        if import_batch:
+            summary += f" Batch: {import_batch}."
         self.stdout.write(self.style.SUCCESS(summary))

--- a/seshat/apps/core/templates/core/partials/_instability_event_badges.html
+++ b/seshat/apps/core/templates/core/partials/_instability_event_badges.html
@@ -1,7 +1,7 @@
 <small style="vertical-align: middle;">
     {% if event.is_llm_source and event.batch_number %}
         <span
-            style="padding-bottom:0px; padding-left:5px; padding-right:5px; padding-top:1px; border-radius:5px; color:white;{% if event.batch_number == 'Batch 1' %} background:#D3D3D3;{% elif event.batch_number == 'Batch 2' %} background:#ADD8E6;{% elif event.batch_number == 'Batch 3' %} background:#a8dcab;{% else %} background:#d9b26f;{% endif %}"
+            style="padding-bottom:0px; padding-left:5px; padding-right:5px; padding-top:1px; border-radius:5px; color:white;{% if event.batch_number == 'Batch 1' %} background:#D3D3D3;{% elif event.batch_number == 'Batch 2' %} background:#ADD8E6;{% elif event.batch_number == 'Batch 3' %} background:#a8dcab;{% elif event.batch_number == 'Batch 4' %} background:#d9b26f;{% elif event.batch_number == 'Batch 5' %} background:#8f7ab8;{% else %} background:#6c757d;{% endif %}"
             data-bs-toggle="tooltip"
             data-bs-html="true"
             title="{{ event.batch_tooltip }}"

--- a/seshat/apps/core/templates/core/partials/_llm_data_row_before.html
+++ b/seshat/apps/core/templates/core/partials/_llm_data_row_before.html
@@ -48,15 +48,11 @@
     {% endif %}            
 
         <small style="vertical-align: top;">
-            {% if form.instance.created_date|date:"Y-m-d" < "2025-03-29" %}
-            <span class="badge bg-secondary"  data-bs-toggle="tooltip" data-bs-html="true" title="Generated in March 2025.">Batch 1</span>
-          {% elif form.instance.created_date|date:"Y-m-d" < "2025-04-11" %}
-            <span class="badge bg-primary" data-bs-toggle="tooltip" data-bs-html="true" title="Generated from March 28th, to April 28th, 2025.">Batch 2</span>
-          {% elif form.instance.created_date|date:"Y-m-d" < "2026-03-01" %}
-            <span class="badge bg-success" data-bs-toggle="tooltip" data-bs-html="true" title="Generated after April 28th, 2025.">Batch 3</span>
-          {% else %}
-            <span class="badge" style="background:#d9b26f;" data-bs-toggle="tooltip" data-bs-html="true" title="Generated on or after March 1st, 2026.">Batch 4</span>
-          {% endif %}
+            {% with batch=form.instance.batch_number %}
+              {% if batch %}
+                <span class="badge" style="{% if batch == 'Batch 1' %}background:#D3D3D3;{% elif batch == 'Batch 2' %}background:#ADD8E6;{% elif batch == 'Batch 3' %}background:#a8dcab;{% elif batch == 'Batch 4' %}background:#d9b26f;{% elif batch == 'Batch 5' %}background:#8f7ab8;{% else %}background:#6c757d;{% endif %}" data-bs-toggle="tooltip" data-bs-html="true" title="{{ form.instance.batch_tooltip }}">{{ batch }}</span>
+              {% endif %}
+            {% endwith %}
         </small>
 
         

--- a/seshat/apps/core/templates/core/partials/_llm_data_row_hidden.html
+++ b/seshat/apps/core/templates/core/partials/_llm_data_row_hidden.html
@@ -5,15 +5,11 @@
 <tr  id="hidden-row-llm" style="border-width:0; display:none; background-image: linear-gradient(to left, rgb(246, 127, 127, 0.056),rgb(242, 199, 119, 0.056),rgb(151, 230, 151, 0.056));">
     <td class="fw-normal text-dark" style="border-width: 0; text-align: left;">  
         <small style="vertical-align: top;">
-            {% if form.instance.created_date|date:"Y-m-d" < "2025-03-29" %}
-            <span class="badge bg-secondary"  data-bs-toggle="tooltip" data-bs-html="true" title="Generated in March 2025.">Batch 1</span>
-          {% elif form.instance.created_date|date:"Y-m-d" < "2025-04-11" %}
-            <span class="badge bg-primary" data-bs-toggle="tooltip" data-bs-html="true" title="Generated from March 28th, to April 28th, 2025.">Batch 2</span>
-          {% elif form.instance.created_date|date:"Y-m-d" < "2026-03-01" %}
-            <span class="badge bg-success" data-bs-toggle="tooltip" data-bs-html="true" title="Generated after April 28th, 2025.">Batch 3</span>
-          {% else %}
-            <span class="badge" style="background:#d9b26f;" data-bs-toggle="tooltip" data-bs-html="true" title="Generated on or after March 1st, 2026.">Batch 4</span>
-          {% endif %}
+            {% with batch=form.instance.batch_number %}
+              {% if batch %}
+                <span class="badge" style="{% if batch == 'Batch 1' %}background:#D3D3D3;{% elif batch == 'Batch 2' %}background:#ADD8E6;{% elif batch == 'Batch 3' %}background:#a8dcab;{% elif batch == 'Batch 4' %}background:#d9b26f;{% elif batch == 'Batch 5' %}background:#8f7ab8;{% else %}background:#6c757d;{% endif %}" data-bs-toggle="tooltip" data-bs-html="true" title="{{ form.instance.batch_tooltip }}">{{ batch }}</span>
+              {% endif %}
+            {% endwith %}
         </small>                         
         <span> {{ form.instance.llm_name|remove_macro_event}}</span>
     </td>

--- a/seshat/apps/core/templates/core/partials/_seshat_data_row_after.html
+++ b/seshat/apps/core/templates/core/partials/_seshat_data_row_after.html
@@ -48,15 +48,11 @@
             {% endif %}
         </span>
         <small style="vertical-align: top;">
-            {% if form.instance.created_date|date:"Y-m-d" < "2025-03-29" %}
-            <span class="badge bg-secondary"  data-bs-toggle="tooltip" data-bs-html="true" title="Generated in March 2025.">Batch 1</span>
-          {% elif form.instance.created_date|date:"Y-m-d" < "2025-04-11" %}
-            <span class="badge bg-primary" data-bs-toggle="tooltip" data-bs-html="true" title="Generated from March 28th, to April 28th, 2025.">Batch 2</span>
-          {% elif form.instance.created_date|date:"Y-m-d" < "2026-03-01" %}
-            <span class="badge bg-success" data-bs-toggle="tooltip" data-bs-html="true" title="Generated after April 28th, 2025.">Batch 3</span>
-          {% else %}
-            <span class="badge" style="background:#d9b26f;" data-bs-toggle="tooltip" data-bs-html="true" title="Generated on or after March 1st, 2026.">Batch 4</span>
-          {% endif %}
+            {% with batch=form.instance.batch_number %}
+              {% if batch %}
+                <span class="badge" style="{% if batch == 'Batch 1' %}background:#D3D3D3;{% elif batch == 'Batch 2' %}background:#ADD8E6;{% elif batch == 'Batch 3' %}background:#a8dcab;{% elif batch == 'Batch 4' %}background:#d9b26f;{% elif batch == 'Batch 5' %}background:#8f7ab8;{% else %}background:#6c757d;{% endif %}" data-bs-toggle="tooltip" data-bs-html="true" title="{{ form.instance.batch_tooltip }}">{{ batch }}</span>
+              {% endif %}
+            {% endwith %}
         </small>   
 <br>
 Macroevent:

--- a/seshat/apps/core/templates/core/polity/polity_detail.html
+++ b/seshat/apps/core/templates/core/polity/polity_detail.html
@@ -2499,10 +2499,9 @@
                                 <label for="selected_batch" class="text-secondary small mb-0">LLM Batch</label>
                                 <select name="selected_batch" id="selected_batch" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
                                     <option value="">All</option>
-                                    <option value="Batch 1" {% if selected_instability_batch == "Batch 1" %}selected{% endif %}>Batch 1</option>
-                                    <option value="Batch 2" {% if selected_instability_batch == "Batch 2" %}selected{% endif %}>Batch 2</option>
-                                    <option value="Batch 3" {% if selected_instability_batch == "Batch 3" %}selected{% endif %}>Batch 3</option>
-                                    <option value="Batch 4" {% if selected_instability_batch == "Batch 4" %}selected{% endif %}>Batch 4</option>
+                                    {% for batch in instability_batch_choices %}
+                                        <option value="{{ batch }}" {% if selected_instability_batch == batch %}selected{% endif %}>{{ batch }}</option>
+                                    {% endfor %}
                                 </select>
                             </div>
                         {% endif %}

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -3,7 +3,7 @@ import importlib
 import random
 import numpy as np
 
-from collections import defaultdict, OrderedDict
+from collections import Counter, defaultdict, OrderedDict
 from seshat.utils.utils import dic_of_all_vars, list_of_all_Polities, dic_of_all_vars_in_sections
 
 from seshat.apps.crisisdb.models import Human_sacrifice
@@ -80,7 +80,10 @@ from ..general.models import Polity_research_assistant, Polity_duration, Polity_
 from ..sc.models import Settlement_hierarchy, Religious_level, Military_level, Administrative_level, Polity_territory, Polity_population
 
 from ..crisisdb.models import Instability_event, Power_transition
-from ..crisisdb.instability_filters import get_polity_instability_queryset
+from ..crisisdb.instability_filters import (
+    VALID_INSTABILITY_BATCHES,
+    get_polity_instability_queryset,
+)
 
 from .models import Citation, Polity, Section, Subsection, Variablehierarchy, Reference, SeshatComment, SeshatCommentPart, Nga, Ngapolityrel, Capital, Seshat_region, Macro_region, Cliopatria, GADMCountries, GADMProvinces, SeshatCommon, ScpThroughCtn, SeshatPrivateComment, SeshatPrivateCommentPart, Religion, HabitationSite, CityPolityRelation
 
@@ -3125,6 +3128,21 @@ class PolityDetailView(SuccessMessageMixin, generic.DetailView):
                 selected_source=selected_instability_source,
                 selected_batch=selected_instability_batch,
             )
+            polity_llm_events = get_polity_instability_queryset(
+                self.object.pk,
+                selected_source=Instability_event.Source.LLM,
+            ).only("created_date", "llm_import_batch")
+            polity_batch_counts = Counter(
+                event.batch_number
+                for event in polity_llm_events
+                if event.batch_number
+            )
+            context["instability_batch_choices"] = [
+                batch
+                for batch in VALID_INSTABILITY_BATCHES
+                if polity_batch_counts.get(batch, 0)
+                or selected_instability_batch == batch
+            ]
             context["show_instability_source_filter"] = bool(
                 selected_instability_source
                 or get_polity_instability_queryset(

--- a/seshat/apps/crisisdb/instability_filters.py
+++ b/seshat/apps/crisisdb/instability_filters.py
@@ -50,6 +50,28 @@ VALID_INSTABILITY_BATCHES = (
     "Batch 2",
     "Batch 3",
     "Batch 4",
+    "Batch 5",
+)
+LEGACY_INSTABILITY_BATCHES = (
+    "Batch 1",
+    "Batch 2",
+    "Batch 3",
+    "Batch 4",
+)
+BATCH_TOOLTIPS = {
+    "Batch 1": "Generated in March 2025.",
+    "Batch 2": "Generated from March 28th, to April 28th, 2025.",
+    "Batch 3": "Generated after April 28th, 2025.",
+    "Batch 4": "Generated on or after March 1st, 2026.",
+    "Batch 5": "Curated agentic LLM review import.",
+}
+BATCH_ORDER = (
+    "Batch 1",
+    "Batch 2",
+    "Batch 3",
+    "Batch 4",
+    "Batch 5",
+    "Unknown",
 )
 INSTABILITY_FILTER_TOKEN_LIMIT = 8
 INSTABILITY_FILTER_TOKEN_GROUP_ORDER = (
@@ -65,7 +87,10 @@ INSTABILITY_FILTER_TOKEN_GROUP_ORDER = (
 )
 
 
-def get_batch_tag(created_date):
+def get_batch_tag(created_date, explicit_batch=None):
+    if explicit_batch:
+        return explicit_batch
+
     if created_date is None:
         return "Unknown"
 
@@ -83,7 +108,10 @@ def get_batch_tag(created_date):
     return "Batch 4"
 
 
-def get_batch_tooltip(created_date):
+def get_batch_tooltip(created_date, explicit_batch=None):
+    if explicit_batch:
+        return BATCH_TOOLTIPS.get(explicit_batch, f"LLM import batch: {explicit_batch}.")
+
     if created_date is None:
         return "Unknown creation date"
 
@@ -92,13 +120,7 @@ def get_batch_tooltip(created_date):
             created_date = timezone.make_aware(created_date)
         created_date = created_date.date()
 
-    if created_date < BATCH_1_END:
-        return "Generated in March 2025."
-    if created_date < BATCH_2_END:
-        return "Generated from March 28th, to April 28th, 2025."
-    if created_date < BATCH_3_END:
-        return "Generated after April 28th, 2025."
-    return "Generated on or after March 1st, 2026."
+    return BATCH_TOOLTIPS[get_batch_tag(created_date)]
 
 
 def normalize_instability_batches(selected_batches):
@@ -123,23 +145,36 @@ def apply_instability_batch_filter(queryset, selected_batches):
     return queryset.filter(build_instability_batch_query(selected_batches))
 
 
-def build_instability_batch_query(selected_batches):
-    selected_batches = normalize_instability_batches(selected_batches)
-    batch_query = Q()
-    if "Batch 1" in selected_batches:
-        batch_query |= Q(created_date__lt=BATCH_1_END_DATETIME)
-    if "Batch 2" in selected_batches:
-        batch_query |= Q(
+def build_missing_explicit_batch_query():
+    return Q(llm_import_batch__isnull=True) | Q(llm_import_batch="")
+
+
+def build_legacy_instability_batch_query(batch):
+    if batch == "Batch 1":
+        return Q(created_date__lt=BATCH_1_END_DATETIME)
+    if batch == "Batch 2":
+        return Q(
             created_date__gte=BATCH_1_END_DATETIME,
             created_date__lt=BATCH_2_END_DATETIME,
         )
-    if "Batch 3" in selected_batches:
-        batch_query |= Q(
+    if batch == "Batch 3":
+        return Q(
             created_date__gte=BATCH_2_END_DATETIME,
             created_date__lt=BATCH_3_END_DATETIME,
         )
-    if "Batch 4" in selected_batches:
-        batch_query |= Q(created_date__gte=BATCH_3_END_DATETIME)
+    if batch == "Batch 4":
+        return Q(created_date__gte=BATCH_3_END_DATETIME)
+    return Q(pk__in=[])
+
+
+def build_instability_batch_query(selected_batches):
+    selected_batches = normalize_instability_batches(selected_batches)
+    batch_query = Q()
+    missing_explicit_batch_query = build_missing_explicit_batch_query()
+    for batch in selected_batches:
+        batch_query |= Q(llm_import_batch=batch)
+        if batch in LEGACY_INSTABILITY_BATCHES:
+            batch_query |= missing_explicit_batch_query & build_legacy_instability_batch_query(batch)
     return batch_query
 
 
@@ -745,6 +780,9 @@ def _build_instability_batch_tokens(base_queryset, search_query):
     tokens = []
     llm_queryset = base_queryset.filter(source=Instability_event.Source.LLM)
     for batch in VALID_INSTABILITY_BATCHES:
+        event_count = apply_instability_batch_filter(llm_queryset, batch).count()
+        if not event_count:
+            continue
         if _token_query_matches(search_query, batch, batch.replace(" ", "")):
             tokens.append(
                 FilterTokenOption(
@@ -752,7 +790,7 @@ def _build_instability_batch_tokens(base_queryset, search_query):
                     value=batch,
                     label=batch,
                     group="LLM Batches",
-                    meta=f"{apply_instability_batch_filter(llm_queryset, batch).count()} events",
+                    meta=f"{event_count} events",
                 )
             )
     return tokens
@@ -1156,26 +1194,22 @@ def build_instability_list_context(model_class, request):
         key=lambda item: (-item[1], item[0]),
     )
 
-    batch_order = ["Batch 1", "Batch 2", "Batch 3", "Batch 4", "Unknown"]
     polity_batch_tags = defaultdict(set)
-    for polity_id, source, created_date in polity_option_queryset.values_list(
+    for polity_id, source, created_date, explicit_batch in polity_option_queryset.values_list(
         "polity_id",
         "source",
         "created_date",
+        "llm_import_batch",
     ):
-        if (
-            polity_id is not None
-            and source == Instability_event.Source.LLM
-            and created_date is not None
-        ):
-            polity_batch_tags[polity_id].add(get_batch_tag(created_date))
+        if polity_id is not None and source == Instability_event.Source.LLM:
+            polity_batch_tags[polity_id].add(get_batch_tag(created_date, explicit_batch))
 
     enriched_polities = []
     for polity in polities:
         batch_list = sorted(
             polity_batch_tags.get(polity.id, set()),
             key=lambda value: (
-                batch_order.index(value) if value in batch_order else len(batch_order)
+                BATCH_ORDER.index(value) if value in BATCH_ORDER else len(BATCH_ORDER)
             ),
         )
         setattr(polity, "event_count", polity_counts.get(polity.id, 0))
@@ -1219,12 +1253,13 @@ def build_instability_list_context(model_class, request):
         ),
     ]
     batch_counts = Counter(
-        get_batch_tag(created_date)
-        for source, created_date in batch_option_queryset.values_list(
+        get_batch_tag(created_date, explicit_batch)
+        for source, created_date, explicit_batch in batch_option_queryset.values_list(
             "source",
             "created_date",
+            "llm_import_batch",
         )
-        if source == Instability_event.Source.LLM and created_date is not None
+        if source == Instability_event.Source.LLM
     )
     batch_filter_choices = [
         (batch, batch_counts.get(batch, 0))

--- a/seshat/apps/crisisdb/migrations/0082_instability_event_llm_import_batch.py
+++ b/seshat/apps/crisisdb/migrations/0082_instability_event_llm_import_batch.py
@@ -1,0 +1,70 @@
+# Generated for explicit instability import batches.
+
+import datetime
+
+from django.db import migrations, models
+from django.utils import timezone
+
+
+BATCH_1_END = datetime.date(2025, 3, 29)
+BATCH_2_END = datetime.date(2025, 4, 11)
+BATCH_3_END = datetime.date(2026, 3, 1)
+BATCH_1_END_DATETIME = timezone.make_aware(
+    datetime.datetime.combine(BATCH_1_END, datetime.time())
+)
+BATCH_2_END_DATETIME = timezone.make_aware(
+    datetime.datetime.combine(BATCH_2_END, datetime.time())
+)
+BATCH_3_END_DATETIME = timezone.make_aware(
+    datetime.datetime.combine(BATCH_3_END, datetime.time())
+)
+
+
+def backfill_llm_import_batches(apps, schema_editor):
+    InstabilityEvent = apps.get_model("crisisdb", "Instability_event")
+    db_alias = schema_editor.connection.alias
+    llm_events = InstabilityEvent.objects.using(db_alias).filter(source="llm")
+
+    llm_events.filter(created_date__lt=BATCH_1_END_DATETIME).update(
+        llm_import_batch="Batch 1"
+    )
+    llm_events.filter(
+        created_date__gte=BATCH_1_END_DATETIME,
+        created_date__lt=BATCH_2_END_DATETIME,
+    ).update(llm_import_batch="Batch 2")
+    llm_events.filter(
+        created_date__gte=BATCH_2_END_DATETIME,
+        created_date__lt=BATCH_3_END_DATETIME,
+    ).update(llm_import_batch="Batch 3")
+    llm_events.filter(created_date__gte=BATCH_3_END_DATETIME).update(
+        llm_import_batch="Batch 4"
+    )
+
+
+def clear_llm_import_batches(apps, schema_editor):
+    InstabilityEvent = apps.get_model("crisisdb", "Instability_event")
+    db_alias = schema_editor.connection.alias
+    InstabilityEvent.objects.using(db_alias).filter(source="llm").update(
+        llm_import_batch=None
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("crisisdb", "0081_alter_instability_event_inst_intensity_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="instability_event",
+            name="llm_import_batch",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                max_length=50,
+                null=True,
+            ),
+        ),
+        migrations.RunPython(backfill_llm_import_batches, clear_llm_import_batches),
+    ]

--- a/seshat/apps/crisisdb/models.py
+++ b/seshat/apps/crisisdb/models.py
@@ -417,6 +417,7 @@ class Instability_event(SeshatCommon):
         choices=Source.choices,
         default=Source.MANUAL,
     )
+    llm_import_batch = models.CharField(max_length=50, null=True, blank=True, db_index=True)
     inst_type = models.ManyToManyField(Instability_type, related_name="%(app_label)s_%(class)s_related",related_query_name="%(app_label)s_%(class)ss", blank=True,)
     ra_check = models.ManyToManyField(Check_choice, related_name="%(app_label)s_%(class)s_related",related_query_name="%(app_label)s_%(class)ss", blank=True,)
     inst_llm_ref = models.ManyToManyField(Instability_ref, related_name="%(app_label)s_%(class)s_related",related_query_name="%(app_label)s_%(class)ss", blank=True,)
@@ -497,7 +498,7 @@ class Instability_event(SeshatCommon):
             return None
         from .instability_filters import get_batch_tag
 
-        return get_batch_tag(self.created_date)
+        return get_batch_tag(self.created_date, self.llm_import_batch)
         
     @property
     def batch_tooltip(self):
@@ -505,7 +506,7 @@ class Instability_event(SeshatCommon):
             return None
         from .instability_filters import get_batch_tooltip
 
-        return get_batch_tooltip(self.created_date)
+        return get_batch_tooltip(self.created_date, self.llm_import_batch)
 
 
     def __str__(self) -> str:

--- a/seshat/apps/crisisdb/templates/crisisdb/instability_analytics.html
+++ b/seshat/apps/crisisdb/templates/crisisdb/instability_analytics.html
@@ -359,10 +359,9 @@
     <label for="selected_batch" class="text-secondary">Batch</label>
     <select name="selected_batch" id="selected_batch" class="form-select" onchange="this.form.submit()">
       <option value="">All</option>
-      <option value="Batch 1" {% if request.GET.selected_batch == "Batch 1" %}selected{% endif %}>Batch 1</option>
-      <option value="Batch 2" {% if request.GET.selected_batch == "Batch 2" %}selected{% endif %}>Batch 2</option>
-      <option value="Batch 3" {% if request.GET.selected_batch == "Batch 3" %}selected{% endif %}>Batch 3</option>
-      <option value="Batch 4" {% if request.GET.selected_batch == "Batch 4" %}selected{% endif %}>Batch 4</option>
+      {% for batch in batch_filter_choices %}
+        <option value="{{ batch.label }}" {% if request.GET.selected_batch == batch.label %}selected{% endif %}>{{ batch.label }}</option>
+      {% endfor %}
     </select>
   </div>
 

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -1252,6 +1252,48 @@ class InstabilityCreateViewTests(TestCase):
         self.assertEqual(manual_events, [manual_event])
         self.assertEqual(llm_batch_one_events, [batch_one_event])
 
+    def test_polity_instability_queryset_filters_by_explicit_batch(self):
+        polity = Polity.objects.create(
+            name="polity_explicit_batch_filter",
+            new_name="polity_explicit_batch_filter",
+            long_name="Polity Explicit Batch Filter",
+            start_year=100,
+            end_year=200,
+        )
+        batch_four_event = Instability_event.objects.create(
+            polity=polity,
+            name="Legacy Batch Four Event",
+            source=Instability_event.Source.LLM,
+            year_from=150,
+            year_to=151,
+        )
+        batch_five_event = Instability_event.objects.create(
+            polity=polity,
+            name="Explicit Batch Five Event",
+            source=Instability_event.Source.LLM,
+            llm_import_batch="Batch 5",
+            year_from=152,
+            year_to=153,
+        )
+        Instability_event.objects.filter(pk=batch_four_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2026, 3, 2))
+        )
+        Instability_event.objects.filter(pk=batch_five_event.pk).update(
+            created_date=timezone.make_aware(datetime.datetime(2026, 3, 2))
+        )
+
+        batch_four_events = list(
+            get_polity_instability_queryset(polity.id, selected_batch="Batch 4")
+        )
+        batch_five_events = list(
+            get_polity_instability_queryset(polity.id, selected_batch="Batch 5")
+        )
+
+        self.assertEqual(batch_four_event.batch_number, "Batch 4")
+        self.assertEqual(batch_five_event.batch_number, "Batch 5")
+        self.assertEqual(batch_four_events, [batch_four_event])
+        self.assertEqual(batch_five_events, [batch_five_event])
+
     def test_polity_detail_instability_batch_filter_renders(self):
         polity = Polity.objects.create(
             name="polity_detail_batch_filter",
@@ -1302,6 +1344,10 @@ class InstabilityCreateViewTests(TestCase):
         self.assertContains(response, "Polity Detail Batch One Event")
         self.assertNotContains(response, "Polity Detail Batch Four Event")
         self.assertNotContains(response, "Polity Detail Manual Event")
+        self.assertEqual(
+            response.context["instability_batch_choices"],
+            ["Batch 1", "Batch 4"],
+        )
 
         manual_response = self.client.get(
             reverse("polity-detail-main", args=[polity.id]),

--- a/seshat/apps/crisisdb/views.py
+++ b/seshat/apps/crisisdb/views.py
@@ -57,6 +57,7 @@ from .models import Power_transition, Crisis_consequence, Human_sacrifice, Exter
 
 from .forms import Power_transitionForm, Crisis_consequenceForm, Human_sacrificeForm, External_conflictForm, Internal_conflictForm, External_conflict_sideForm, Agricultural_populationForm, Arable_landForm, Arable_land_per_farmerForm, Gross_grain_shared_per_agricultural_populationForm, Net_grain_shared_per_agricultural_populationForm, SurplusForm, Military_expenseForm, Silver_inflowForm, Silver_stockForm, Total_populationForm, Gdp_per_capitaForm, Drought_eventForm, Locust_eventForm, Socioeconomic_turmoil_eventForm, Crop_failure_eventForm, Famine_eventForm, Disease_outbreakForm, Us_locationForm, Us_violence_subtypeForm, Us_violence_data_sourceForm, Us_violenceForm, CheckChoiceForm
 from .instability_filters import (
+    VALID_INSTABILITY_BATCHES,
     apply_instability_batch_filter,
     build_instability_filter_token_response,
     get_batch_tag,
@@ -6356,8 +6357,21 @@ def instability_analytics(request):
         polity__unreliable_instability_events=False,
         source=Instability_event.Source.LLM,
     ).only(
-        'id', 'created_date', 'source', 'inst_extent', 'inst_intensity', 'real_event_check', 'inst_type', 'ra_check', 'curator', 'comment', 'private_comment'
+        'id', 'created_date', 'source', 'llm_import_batch', 'inst_extent', 'inst_intensity', 'real_event_check', 'inst_type', 'ra_check', 'curator', 'comment', 'private_comment'
     )
+    selected_batch = request.GET.get('selected_batch')
+    batch_filter_counts = Counter(
+        get_batch_tag(created_date, explicit_batch)
+        for created_date, explicit_batch in queryset.values_list(
+            "created_date",
+            "llm_import_batch",
+        )
+    )
+    batch_filter_choices = [
+        {"label": batch, "count": batch_filter_counts.get(batch, 0)}
+        for batch in VALID_INSTABILITY_BATCHES
+        if batch_filter_counts.get(batch, 0) or selected_batch == batch
+    ]
 
     all_events_count= len(queryset)
 
@@ -6387,8 +6401,6 @@ def instability_analytics(request):
             selected_researcher = None
     else:
         selected_researcher = None
-
-    selected_batch = request.GET.get('selected_batch')
 
     if selected_batch:
         queryset = apply_instability_batch_filter(queryset, selected_batch)
@@ -6517,7 +6529,11 @@ def instability_analytics(request):
 
     # Step 1: Assign batch label per event
     batch_labels = [
-            get_batch_tag(dt) for dt in queryset.values_list("created_date", flat=True)
+        get_batch_tag(created_date, explicit_batch)
+        for created_date, explicit_batch in queryset.values_list(
+            "created_date",
+            "llm_import_batch",
+        )
     ]
 
     # Step 2: Count occurrences
@@ -6715,6 +6731,7 @@ def instability_analytics(request):
         "check_choices": Check_choice.objects.all(),
         "selected_ra_check_ids": selected_ra_check_ids,
         'batch_data': batch_data,
+        "batch_filter_choices": batch_filter_choices,
         "intensity_comp_chart_data": intensity_comp_chart_data,
         "extent_comp_chart_data": extent_comp_chart_data,
         "year_range_comp_chart_data": year_range_comp_chart_data,


### PR DESCRIPTION
## Summary

This PR makes instability-event LLM import batches explicit data rather than deriving them only from `created_date`.

Changes:
- Adds `Instability_event.llm_import_batch`.
- Adds a migration that backfills existing LLM rows into Batch 1-4 using the legacy date thresholds.
- Updates batch labels, tooltips, filters, analytics, polity detail views, and LLM badges to prefer the explicit batch field while preserving the old date fallback for legacy/unset rows.
- Adds `--batch` support to the instability CSV importer so future curated imports can be tagged, for example as Batch 5.


## Motivation

Previously, instability-event batches were inferred from creation dates. That worked for the first LLM import waves, but it makes future imports fragile because batch identity depends on when rows are created rather than what import process they came from.


