### PR TITLE
Improve instability list rendering performance

### DIFF
--- a/seshat/apps/core/templates/core/list_base_for_new_approach.html
+++ b/seshat/apps/core/templates/core/list_base_for_new_approach.html
@@ -270,7 +270,7 @@
 
       
       
-    {% if object_list or request.GET.year_from_min or request.GET.year_to_max or request.GET.created_before or request.GET.polity or request.GET.selected_batch or request.GET.inst_type  or request.GET.ra_check or request.GET.inst_extent or request.GET.inst_intensity or request.GET.searched_name or request.GET.macro_event or request.GET.is_macro_event %}
+    {% if record_count or request.GET or object_list %}
     <div class="row d-flex">
         <div class="col-md-9">
             <!-- <h5 class="lead-2">List of all the data for: {{object_list.0.section}}</h5> -->

--- a/seshat/apps/general/views.py
+++ b/seshat/apps/general/views.py
@@ -1956,6 +1956,13 @@ def generic_list_view(request, model_class, var_name, coded_value, var_name_disp
     paginator = Paginator(object_list, current_per_page)
     page_number = request.GET.get("page")
     page_obj = paginator.get_page(page_number)
+    if var_name == "instability_event":
+        page_obj.object_list = page_obj.object_list.select_related(
+            "polity"
+        ).prefetch_related(
+            "inst_type",
+            "ra_check",
+        )
     context['page_obj'] = page_obj
     context['paginated'] = True
     context["current_per_page_value"] = requested_per_page


### PR DESCRIPTION
## Summary

This PR adds a small performance improvement for the instability event list.

- Avoids evaluating the full generic list queryset in the shared list template when `record_count` or query params are already available.
- Prefetches `polity`, `inst_type`, and `ra_check` for the current instability-event page after pagination.
- Keeps the shared template compatible with older list contexts by retaining `object_list` as a fallback.

## Validation

- Ran `python3 manage.py check`

  - `/crisisdb/instability_events_all/`
  - `/crisisdb/instability_events_all/?q=unlikely_no_match_zzzz`
  - `/sc/polity_territorys_all/`
  - `/wf/long_walls_all/`

