### PR TITLE
Coinhoards data model update

### DIFF
--- a/seshat/apps/core/management/commands/import_coinhoards.py
+++ b/seshat/apps/core/management/commands/import_coinhoards.py
@@ -1,5 +1,5 @@
 """
-Import CHRE coin hoard CSV rows into ``core.CoinHoard``.
+Import coin hoard CSV rows into ``core.CoinHoard``.
 
 Django management command name (from this filename): ``import_coinhoards``.
 
@@ -14,8 +14,9 @@ Integration steps (run from the directory that contains ``manage.py``, e.g.
 
        python manage.py showmigrations core
 
-2. **Import the CHRE export CSV** (UTF-8 with BOM is fine; the importer uses
-   ``utf-8-sig``). Example::
+2. **Import a coin hoard CSV** (UTF-8 with BOM is fine; the importer uses
+   ``utf-8-sig``). The command supports both the original CHRE export and the
+   Seshat-shaped model-ready CSVs. Example::
 
        python manage.py import_coinhoards \\
            --csv "/path/to/CHRE_hoard_export_YYYY_MM_DD.csv" \\
@@ -37,10 +38,12 @@ Integration steps (run from the directory that contains ``manage.py``, e.g.
        python manage.py shell -c \\
            "from seshat.apps.core.models import CoinHoard; print(CoinHoard.objects.count())"
 
-**CSV expectations**: columns such as ``id``, ``hoardName``, ``coinCount``,
-``terminalYear1``/``terminalYear2``, ``openingYear1``/``openingYear2``,
-``discoveryYear1``/``discoveryYear2``, ``permalinkOnlineDatabases`` (mixed text
-and URLs), coordinates, etc., as produced by the CHRE export.
+**CSV expectations**: either CHRE export columns such as ``id``, ``hoardName``,
+``coinCount``, ``terminalYear1``/``terminalYear2``, ``openingYear1``/
+``openingYear2``, ``discoveryYear1``/``discoveryYear2``,
+``permalinkOnlineDatabases``; or Seshat-shaped columns such as
+``external_dataset_id``, ``data_source``, ``hoard_name``, ``number_of_coins``,
+``year_from``/``year_to`` and ``deposit_year_from``/``deposit_year_to``.
 
 **UI**: list at ``/core/coinhoards/`` (name ``coinhoards``); canonical CHRE
 permalink for a hoard is built in views as
@@ -148,6 +151,101 @@ def normalize_choice(value, allowed_values):
     return value if value in allowed_values else ""
 
 
+def is_model_ready_row(row):
+    return normalize_str(row.get("external_dataset_id")) != ""
+
+
+def normalize_model_ready_payload(row):
+    ext_id = clip_str(row.get("external_dataset_id"), 32)
+    if not ext_id:
+        return None
+    return {
+        "external_dataset_id": ext_id,
+        "raw_external_id": clip_str(row.get("raw_external_id"), 32),
+        "data_source": clip_str(row.get("data_source"), 128) or DEFAULT_SOURCE,
+        "hoard_name": clip_str(row.get("hoard_name"), 255),
+        "number_of_coins": parse_int(row.get("number_of_coins")),
+        "discovery_method": normalize_choice(
+            row.get("discovery_method"),
+            {choice[0] for choice in CoinHoard.DISCOVERY_METHOD_CHOICES},
+        ),
+        "discovery_year1": parse_int(row.get("discovery_year1")),
+        "discovery_year2": parse_int(row.get("discovery_year2")),
+        "opening_year1": parse_int(row.get("opening_year1")),
+        "opening_year2": parse_int(row.get("opening_year2")),
+        "year_from": parse_int(row.get("year_from")),
+        "year_to": parse_int(row.get("year_to")),
+        "deposit_year_from": parse_int(row.get("deposit_year_from")),
+        "deposit_year_to": parse_int(row.get("deposit_year_to")),
+        "deposit_display": clip_str(row.get("deposit_display"), 255),
+        "find_spot_rating": normalize_choice(
+            row.get("find_spot_rating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
+        ),
+        "contextual_rating": normalize_choice(
+            row.get("contextual_rating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
+        ),
+        "numismatic_rating": normalize_choice(
+            row.get("numismatic_rating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
+        ),
+        "latitude": parse_decimal(row.get("latitude")),
+        "longitude": parse_decimal(row.get("longitude")),
+        "altitude": parse_decimal(row.get("altitude")),
+        "city": clip_str(row.get("city"), 255),
+        "county": clip_str(row.get("county"), 255),
+        "region": clip_str(row.get("region"), 255),
+        "country": clip_str(row.get("country"), 255),
+        "summary": normalize_str(row.get("summary")),
+        "external_source_text": normalize_str(row.get("external_source_text")),
+        "external_url": clip_str(row.get("external_url"), 500),
+    }
+
+
+def normalize_chre_payload(row):
+    ext_id = make_external_dataset_id(row.get("id"))
+    if not ext_id:
+        return None
+    external_source_text, external_url = parse_external_source(row.get("permalinkOnlineDatabases"))
+    return {
+        "external_dataset_id": ext_id,
+        "raw_external_id": normalize_str(row.get("id")),
+        "data_source": DEFAULT_SOURCE,
+        "hoard_name": normalize_str(row.get("hoardName")),
+        "number_of_coins": parse_int(row.get("coinCount")),
+        "discovery_method": normalize_choice(
+            row.get("discoveryMethod"),
+            {choice[0] for choice in CoinHoard.DISCOVERY_METHOD_CHOICES},
+        ),
+        "discovery_year1": parse_int(row.get("discoveryYear1")),
+        "discovery_year2": parse_int(row.get("discoveryYear2")),
+        "opening_year1": parse_int(row.get("openingYear1")),
+        "opening_year2": parse_int(row.get("openingYear2")),
+        "year_from": parse_int(row.get("terminalYear1")),
+        "year_to": parse_int(row.get("terminalYear2")),
+        "deposit_year_from": None,
+        "deposit_year_to": None,
+        "deposit_display": "",
+        "find_spot_rating": normalize_choice(
+            row.get("findSpotRating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
+        ),
+        "contextual_rating": normalize_choice(
+            row.get("contextualRating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
+        ),
+        "numismatic_rating": normalize_choice(
+            row.get("numismaticRating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
+        ),
+        "latitude": parse_decimal(row.get("latitude")),
+        "longitude": parse_decimal(row.get("longitude")),
+        "altitude": parse_decimal(row.get("altitude")),
+        "city": clip_str(row.get("city"), 255),
+        "county": clip_str(row.get("county"), 255),
+        "region": clip_str(choose_region(row), 255),
+        "country": clip_str(row.get("country"), 255),
+        "summary": normalize_str(row.get("summary")),
+        "external_source_text": external_source_text,
+        "external_url": clip_str(external_url, 500),
+    }
+
+
 def next_seshat_id(existing_max):
     if not existing_max:
         return 1
@@ -158,10 +256,10 @@ def next_seshat_id(existing_max):
 
 
 class Command(BaseCommand):
-    help = "Import CHRE CSV into core.CoinHoard. See module docstring for migrate + import commands."
+    help = "Import coin hoard CSV into core.CoinHoard. See module docstring for supported formats."
 
     def add_arguments(self, parser):
-        parser.add_argument("--csv", required=True, help="Path to CHRE CSV file")
+        parser.add_argument("--csv", required=True, help="Path to coin hoard CSV file")
         parser.add_argument("--chunk-size", type=int, default=2000, help="Bulk operation chunk size")
 
     def handle(self, *args, **options):
@@ -176,60 +274,27 @@ class Command(BaseCommand):
 
         normalized = []
         for row in rows:
-            ext_id = make_external_dataset_id(row.get("id"))
-            if ext_id:
-                normalized.append((row, ext_id))
+            payload = (
+                normalize_model_ready_payload(row)
+                if is_model_ready_row(row)
+                else normalize_chre_payload(row)
+            )
+            if payload:
+                normalized.append(payload)
 
         existing = {
             obj.external_dataset_id: obj
-            for obj in CoinHoard.objects.filter(external_dataset_id__in=[ext for _, ext in normalized])
+            for obj in CoinHoard.objects.filter(
+                external_dataset_id__in=[payload["external_dataset_id"] for payload in normalized]
+            )
         }
         seshat_counter = next_seshat_id(CoinHoard.objects.aggregate(mx=Max("seshat_id")).get("mx"))
 
         to_create = []
         to_update = []
 
-        for row, ext_id in normalized:
-            external_source_text, external_url = parse_external_source(
-                row.get("permalinkOnlineDatabases")
-            )
-            payload = {
-                "external_dataset_id": ext_id,
-                "raw_external_id": normalize_str(row.get("id")),
-                "data_source": DEFAULT_SOURCE,
-                "hoard_name": normalize_str(row.get("hoardName")),
-                "number_of_coins": parse_int(row.get("coinCount")),
-                "discovery_method": normalize_choice(
-                    row.get("discoveryMethod"),
-                    {choice[0] for choice in CoinHoard.DISCOVERY_METHOD_CHOICES},
-                ),
-                "discovery_year1": parse_int(row.get("discoveryYear1")),
-                "discovery_year2": parse_int(row.get("discoveryYear2")),
-                "opening_year1": parse_int(row.get("openingYear1")),
-                "opening_year2": parse_int(row.get("openingYear2")),
-                "year_from": parse_int(row.get("terminalYear1")),
-                "year_to": parse_int(row.get("terminalYear2")),
-                "find_spot_rating": normalize_choice(
-                    row.get("findSpotRating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
-                ),
-                "contextual_rating": normalize_choice(
-                    row.get("contextualRating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
-                ),
-                "numismatic_rating": normalize_choice(
-                    row.get("numismaticRating"), {choice[0] for choice in CoinHoard.RATING_CHOICES}
-                ),
-                "latitude": parse_decimal(row.get("latitude")),
-                "longitude": parse_decimal(row.get("longitude")),
-                "altitude": parse_decimal(row.get("altitude")),
-                "city": clip_str(row.get("city"), 255),
-                "county": clip_str(row.get("county"), 255),
-                "region": clip_str(choose_region(row), 255),
-                "country": clip_str(row.get("country"), 255),
-                "summary": normalize_str(row.get("summary")),
-                "external_source_text": external_source_text,
-                "external_url": clip_str(external_url, 500),
-            }
-
+        for payload in normalized:
+            ext_id = payload["external_dataset_id"]
             obj = existing.get(ext_id)
             if obj is None:
                 payload["seshat_id"] = f"{seshat_counter:06d}"
@@ -257,6 +322,9 @@ class Command(BaseCommand):
             "opening_year2",
             "year_from",
             "year_to",
+            "deposit_year_from",
+            "deposit_year_to",
+            "deposit_display",
             "find_spot_rating",
             "contextual_rating",
             "numismatic_rating",

--- a/seshat/apps/core/management/commands/import_coinhoards.py
+++ b/seshat/apps/core/management/commands/import_coinhoards.py
@@ -31,7 +31,9 @@ Integration steps (run from the directory that contains ``manage.py``, e.g.
 
 3. **Re-runs are safe**: rows are keyed by ``external_dataset_id`` (e.g.
    ``CHRE04630`` from CSV ``id``). Existing rows are updated; new rows are
-   created and ``seshat_id`` is assigned for new records only.
+   created and ``seshat_id`` is assigned for new records only. Model-ready
+   CSVs are full-record imports: the command rejects files missing any modeled
+   column rather than treating absent columns as blank values.
 
 4. **Quick sanity check** (optional)::
 
@@ -68,6 +70,36 @@ from seshat.apps.core.models import CoinHoard
 
 NULL_LIKE = {"", "not available", "n/a", "none", "null", "unknown"}
 DEFAULT_SOURCE = "Coin Hoards of the Roman Empire"
+MODEL_READY_REQUIRED_COLUMNS = (
+    "external_dataset_id",
+    "raw_external_id",
+    "data_source",
+    "hoard_name",
+    "number_of_coins",
+    "discovery_method",
+    "discovery_year1",
+    "discovery_year2",
+    "opening_year1",
+    "opening_year2",
+    "year_from",
+    "year_to",
+    "deposit_year_from",
+    "deposit_year_to",
+    "deposit_display",
+    "find_spot_rating",
+    "contextual_rating",
+    "numismatic_rating",
+    "latitude",
+    "longitude",
+    "altitude",
+    "city",
+    "county",
+    "region",
+    "country",
+    "summary",
+    "external_source_text",
+    "external_url",
+)
 
 
 def normalize_str(value):
@@ -151,18 +183,45 @@ def normalize_choice(value, allowed_values):
     return value if value in allowed_values else ""
 
 
-def is_model_ready_row(row):
-    return normalize_str(row.get("external_dataset_id")) != ""
+def validate_model_ready_csv(fieldnames, rows):
+    missing = sorted(set(MODEL_READY_REQUIRED_COLUMNS) - set(fieldnames))
+    if missing:
+        raise CommandError(
+            "Model-ready CSV is incomplete and was not imported. Missing columns: "
+            + ", ".join(missing)
+        )
+
+    seen_ids = {}
+    for row_number, row in enumerate(rows, start=2):
+        ext_id = normalize_str(row.get("external_dataset_id"))
+        if not ext_id:
+            raise CommandError(
+                f"Model-ready CSV row {row_number} has a blank external_dataset_id."
+            )
+        if len(ext_id) > 32:
+            raise CommandError(
+                f"Model-ready CSV row {row_number} has an external_dataset_id longer than 32 characters: {ext_id}"
+            )
+        if not normalize_str(row.get("data_source")):
+            raise CommandError(
+                f"Model-ready CSV row {row_number} ({ext_id}) has a blank data_source."
+            )
+        first_row = seen_ids.get(ext_id)
+        if first_row is not None:
+            raise CommandError(
+                f"Duplicate external_dataset_id {ext_id} in model-ready CSV rows {first_row} and {row_number}."
+            )
+        seen_ids[ext_id] = row_number
 
 
 def normalize_model_ready_payload(row):
-    ext_id = clip_str(row.get("external_dataset_id"), 32)
+    ext_id = normalize_str(row.get("external_dataset_id"))
     if not ext_id:
         return None
     return {
         "external_dataset_id": ext_id,
         "raw_external_id": clip_str(row.get("raw_external_id"), 32),
-        "data_source": clip_str(row.get("data_source"), 128) or DEFAULT_SOURCE,
+        "data_source": clip_str(row.get("data_source"), 128),
         "hoard_name": clip_str(row.get("hoard_name"), 255),
         "number_of_coins": parse_int(row.get("number_of_coins")),
         "discovery_method": normalize_choice(
@@ -268,18 +327,34 @@ class Command(BaseCommand):
 
         try:
             with open(csv_path, newline="", encoding="utf-8-sig") as handle:
-                rows = list(csv.DictReader(handle))
+                reader = csv.DictReader(handle)
+                fieldnames = reader.fieldnames or []
+                rows = list(reader)
         except FileNotFoundError as exc:
             raise CommandError(f"CSV not found: {csv_path}") from exc
 
-        normalized = []
-        for row in rows:
-            payload = (
-                normalize_model_ready_payload(row)
-                if is_model_ready_row(row)
-                else normalize_chre_payload(row)
+        if not fieldnames:
+            raise CommandError("CSV is missing a header row.")
+
+        is_model_ready_csv = "external_dataset_id" in fieldnames
+        if is_model_ready_csv:
+            validate_model_ready_csv(fieldnames, rows)
+        elif "id" not in fieldnames:
+            raise CommandError(
+                "Unrecognized coin-hoard CSV schema: expected external_dataset_id or legacy CHRE id column."
             )
+
+        normalized = []
+        seen_ids = set()
+        for row_number, row in enumerate(rows, start=2):
+            payload = normalize_model_ready_payload(row) if is_model_ready_csv else normalize_chre_payload(row)
             if payload:
+                ext_id = payload["external_dataset_id"]
+                if ext_id in seen_ids:
+                    raise CommandError(
+                        f"Duplicate external_dataset_id {ext_id} at CSV row {row_number}."
+                    )
+                seen_ids.add(ext_id)
                 normalized.append(payload)
 
         existing = {

--- a/seshat/apps/core/management/commands/map_coinhoards_to_polities.py
+++ b/seshat/apps/core/management/commands/map_coinhoards_to_polities.py
@@ -22,27 +22,40 @@ def normalize_range(start, end):
     return (start, end) if start <= end else (end, start)
 
 
+def coin_hoard_temporal_anchor(coin_hoard):
+    if coin_hoard.deposit_year_from is not None:
+        return coin_hoard.deposit_year_from, "deposit"
+    if coin_hoard.deposit_year_to is not None:
+        return coin_hoard.deposit_year_to, "deposit"
+    if coin_hoard.year_from is not None:
+        return coin_hoard.year_from, "terminal_fallback"
+    if coin_hoard.year_to is not None:
+        return coin_hoard.year_to, "terminal_fallback"
+    return None, ""
+
+
 def map_coinhoard_to_polities(coin_hoard, polities_by_seshat_id):
     """
     Return CoinHoardPolityMapping rows for one CoinHoard.
     Mapping criteria:
     1) hoard has a point (lon/lat),
-    2) terminal anchor year exists (year_from, fallback year_to),
+    2) deposit anchor year exists, falling back to terminal chronology when
+       deposit chronology is unavailable,
     3) Cliopatria polygon contains the point,
     4) anchor year falls within Cliopatria shape year range and Polity year range.
     """
     if coin_hoard.latitude is None or coin_hoard.longitude is None:
         return []
 
-    terminal_anchor_year = coin_hoard.year_from if coin_hoard.year_from is not None else coin_hoard.year_to
-    if terminal_anchor_year is None:
+    anchor_year, match_basis = coin_hoard_temporal_anchor(coin_hoard)
+    if anchor_year is None:
         return []
 
     point = Point(float(coin_hoard.longitude), float(coin_hoard.latitude), srid=4326)
     candidate_shapes = Cliopatria.objects.filter(
         geom__contains=point,
-        start_year__lte=terminal_anchor_year,
-        end_year__gte=terminal_anchor_year,
+        start_year__lte=anchor_year,
+        end_year__gte=anchor_year,
     ).only("id", "seshat_id", "start_year", "end_year").order_by("id")
 
     mappings = []
@@ -56,10 +69,10 @@ def map_coinhoard_to_polities(coin_hoard, polities_by_seshat_id):
             polity_start, polity_end = normalize_range(polity.start_year, polity.end_year)
             if polity_start is None:
                 continue
-            if not (polity_start <= terminal_anchor_year <= polity_end):
+            if not (polity_start <= anchor_year <= polity_end):
                 continue
 
-            if not (shape.start_year <= terminal_anchor_year <= shape.end_year):
+            if not (shape.start_year <= anchor_year <= shape.end_year):
                 continue
 
             mappings.append(
@@ -67,8 +80,9 @@ def map_coinhoard_to_polities(coin_hoard, polities_by_seshat_id):
                     coin_hoard=coin_hoard,
                     polity=polity,
                     cliopatria_shape=shape,
-                    overlap_year_from=terminal_anchor_year,
-                    overlap_year_to=terminal_anchor_year,
+                    overlap_year_from=anchor_year,
+                    overlap_year_to=anchor_year,
+                    temporal_match_basis=match_basis,
                 )
             )
             matched_polity_ids.add(polity.id)

--- a/seshat/apps/core/migrations/0090_coinhoard_deposit_dates.py
+++ b/seshat/apps/core/migrations/0090_coinhoard_deposit_dates.py
@@ -1,0 +1,39 @@
+# Generated manually for coin hoard deposit chronology fields
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0089_remove_coinhoard_core_coinho_data_so_b72e26_idx_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="coinhoard",
+            name="deposit_year_from",
+            field=models.IntegerField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="coinhoard",
+            name="deposit_year_to",
+            field=models.IntegerField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="coinhoard",
+            name="deposit_display",
+            field=models.CharField(blank=True, default="", max_length=255),
+        ),
+        migrations.AddField(
+            model_name="coinhoardpolitymapping",
+            name="temporal_match_basis",
+            field=models.CharField(blank=True, default="", max_length=32),
+        ),
+        migrations.AddIndex(
+            model_name="coinhoard",
+            index=models.Index(
+                fields=["data_source", "deposit_year_from", "deposit_year_to"],
+                name="core_coinho_data_so_c2c150_idx",
+            ),
+        ),
+    ]

--- a/seshat/apps/core/models.py
+++ b/seshat/apps/core/models.py
@@ -685,6 +685,9 @@ class CoinHoard(models.Model):
 
     year_from = models.IntegerField(null=True, blank=True, db_index=True)
     year_to = models.IntegerField(null=True, blank=True, db_index=True)
+    deposit_year_from = models.IntegerField(null=True, blank=True, db_index=True)
+    deposit_year_to = models.IntegerField(null=True, blank=True, db_index=True)
+    deposit_display = models.CharField(max_length=255, blank=True, default="")
     find_spot_rating = models.CharField(max_length=1, choices=RATING_CHOICES, blank=True, default="")
     contextual_rating = models.CharField(max_length=1, choices=RATING_CHOICES, blank=True, default="")
     numismatic_rating = models.CharField(max_length=1, choices=RATING_CHOICES, blank=True, default="")
@@ -708,6 +711,10 @@ class CoinHoard(models.Model):
     class Meta:
         indexes = [
             models.Index(fields=["data_source", "year_from", "year_to"]),
+            models.Index(
+                fields=["data_source", "deposit_year_from", "deposit_year_to"],
+                name="core_coinho_data_so_c2c150_idx",
+            ),
             models.Index(fields=["region"]),
         ]
         ordering = ["external_dataset_id"]
@@ -736,6 +743,7 @@ class CoinHoardPolityMapping(models.Model):
     )
     overlap_year_from = models.IntegerField(null=True, blank=True)
     overlap_year_to = models.IntegerField(null=True, blank=True)
+    temporal_match_basis = models.CharField(max_length=32, blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -1868,7 +1876,6 @@ class GADMShapefile(models.Model):
 
     def __str__(self):
         return "Name: %s" % self.name
-    
 class GADMCountries(models.Model):
     """
     Model representing a country (GADM).
@@ -1878,7 +1885,6 @@ class GADMCountries(models.Model):
 
     def __str__(self):
         return "Name: %s" % self.name
-    
 class GADMProvinces(models.Model):
     """
     Model representing a province (GADM).
@@ -1890,4 +1896,3 @@ class GADMProvinces(models.Model):
 
     def __str__(self):
         return "Name: %s" % self.name
-    

--- a/seshat/apps/core/templates/core/coinhoards/hoard_detail.html
+++ b/seshat/apps/core/templates/core/coinhoards/hoard_detail.html
@@ -164,7 +164,7 @@
 </style>
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-start mb-1">
-        <h2 class="mb-0">{{ hoard.external_dataset_id_label }}</h2>
+        <h2 class="mb-0">{{ hoard.external_dataset_id }}</h2>
         <a class="btn btn-secondary btn-sm" href="{% url 'coinhoards' %}">Back to list</a>
     </div>
     <p class="text-secondary">{{ hoard.hoard_name|default:"Unnamed hoard" }}</p>

--- a/seshat/apps/core/templates/core/coinhoards/hoard_detail.html
+++ b/seshat/apps/core/templates/core/coinhoards/hoard_detail.html
@@ -164,7 +164,7 @@
 </style>
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-start mb-1">
-        <h2 class="mb-0">{{ hoard.external_dataset_id }}</h2>
+        <h2 class="mb-0">{{ hoard.external_dataset_id_label }}</h2>
         <a class="btn btn-secondary btn-sm" href="{% url 'coinhoards' %}">Back to list</a>
     </div>
     <p class="text-secondary">{{ hoard.hoard_name|default:"Unnamed hoard" }}</p>
@@ -172,11 +172,11 @@
         <small class="text-secondary">Data read date: <b>9 March 2026</b></small>
     </div>
     <div class="mb-3 d-flex gap-2">
-        {% if hoard.chre_url %}
-            <a class="btn btn-sm btn-outline-dark" href="{{ hoard.chre_url }}" target="_blank" rel="noopener noreferrer">Open Original CHRE Record</a>
+        {% if hoard.source_record_url %}
+            <a class="btn btn-sm btn-outline-dark" href="{{ hoard.source_record_url }}" target="_blank" rel="noopener noreferrer">Open Source Record</a>
         {% endif %}
-        {% if hoard.external_url %}
-            <a class="btn btn-sm btn-outline-secondary" href="{{ hoard.external_url }}" target="_blank" rel="noopener noreferrer">Open External Link</a>
+        {% if hoard.external_url and hoard.external_url != hoard.source_record_url %}
+            <a class="btn btn-sm btn-outline-secondary" href="{{ hoard.external_url }}" target="_blank" rel="noopener noreferrer">Open Source Dataset</a>
         {% endif %}
     </div>
     <div class="hoard-legend-row">
@@ -184,6 +184,7 @@
             <small class="text-secondary">
                 <b>Year meaning:</b>
                 <b>Terminal</b> = date range of latest coin issue in hoard;
+                <b>Deposit</b> = estimated burial/deposition date;
                 <b>Discovery</b> = when the hoard was discovered;
                 <b>Opening</b> = date range of the earliest coin issue in the hoard.
             </small>
@@ -204,6 +205,7 @@
                 <table class="table table-sm table-borderless mb-0 detail-record-table">
                     <tr><th>Opening</th><td>{% if hoard.opening_year1 and hoard.opening_year2 %}{% if hoard.opening_year1 == hoard.opening_year2 %}{% if hoard.opening_year1 < 0 %}<span class="year-num">{{ hoard.opening_year1|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.opening_year1 }}</span> <span class="year-era">CE</span>{% endif %}{% else %}{% if hoard.opening_year1 < 0 %}<span class="year-num">{{ hoard.opening_year1|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.opening_year1 }}</span> <span class="year-era">CE</span>{% endif %} <span class="year-arrow">&rarr;</span> {% if hoard.opening_year2 < 0 %}<span class="year-num">{{ hoard.opening_year2|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.opening_year2 }}</span> <span class="year-era">CE</span>{% endif %}{% endif %}{% elif hoard.opening_year1 %}{% if hoard.opening_year1 < 0 %}<span class="year-num">{{ hoard.opening_year1|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.opening_year1 }}</span> <span class="year-era">CE</span>{% endif %}{% elif hoard.opening_year2 %}{% if hoard.opening_year2 < 0 %}<span class="year-num">{{ hoard.opening_year2|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.opening_year2 }}</span> <span class="year-era">CE</span>{% endif %}{% else %}-{% endif %}</td></tr>
                     <tr><th>Terminal</th><td>{% if hoard.year_from and hoard.year_to %}{% if hoard.year_from == hoard.year_to %}{% if hoard.year_from < 0 %}<span class="year-num">{{ hoard.year_from|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_from }}</span> <span class="year-era">CE</span>{% endif %}{% else %}{% if hoard.year_from < 0 %}<span class="year-num">{{ hoard.year_from|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_from }}</span> <span class="year-era">CE</span>{% endif %} <span class="year-arrow">&rarr;</span> {% if hoard.year_to < 0 %}<span class="year-num">{{ hoard.year_to|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_to }}</span> <span class="year-era">CE</span>{% endif %}{% endif %}{% elif hoard.year_from %}{% if hoard.year_from < 0 %}<span class="year-num">{{ hoard.year_from|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_from }}</span> <span class="year-era">CE</span>{% endif %}{% elif hoard.year_to %}{% if hoard.year_to < 0 %}<span class="year-num">{{ hoard.year_to|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_to }}</span> <span class="year-era">CE</span>{% endif %}{% else %}-{% endif %}</td></tr>
+                    <tr><th>Deposit</th><td>{{ hoard.deposit_year_label|default:"-" }}</td></tr>
                     <tr><th>Discovery</th><td>{% if hoard.discovery_year1 and hoard.discovery_year2 %}{% if hoard.discovery_year1 == hoard.discovery_year2 %}{% if hoard.discovery_year1 < 0 %}<span class="year-num">{{ hoard.discovery_year1|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.discovery_year1 }}</span> <span class="year-era">CE</span>{% endif %}{% else %}{% if hoard.discovery_year1 < 0 %}<span class="year-num">{{ hoard.discovery_year1|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.discovery_year1 }}</span> <span class="year-era">CE</span>{% endif %} <span class="year-arrow">&rarr;</span> {% if hoard.discovery_year2 < 0 %}<span class="year-num">{{ hoard.discovery_year2|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.discovery_year2 }}</span> <span class="year-era">CE</span>{% endif %}{% endif %}{% elif hoard.discovery_year1 %}{% if hoard.discovery_year1 < 0 %}<span class="year-num">{{ hoard.discovery_year1|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.discovery_year1 }}</span> <span class="year-era">CE</span>{% endif %}{% elif hoard.discovery_year2 %}{% if hoard.discovery_year2 < 0 %}<span class="year-num">{{ hoard.discovery_year2|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.discovery_year2 }}</span> <span class="year-era">CE</span>{% endif %}{% else %}-{% endif %}</td></tr>
                     <tr><th>City</th><td>{{ hoard.city|default:"-" }}</td></tr>
                     <tr><th>County</th><td>{{ hoard.county|default:"-" }}</td></tr>
@@ -239,12 +241,12 @@
                     <tr><th>External source</th><td>{{ hoard.external_source_text|default:"-" }}</td></tr>
                     <tr><th>Summary</th><td>{{ hoard.summary|default:"-" }}</td></tr>
                     <tr>
-                        <th>External URL</th>
+                        <th>Source/dataset URL</th>
                         <td>{% if hoard.external_url %}<a href="{{ hoard.external_url }}" target="_blank" rel="noopener noreferrer">{{ hoard.external_url }}</a>{% else %}-{% endif %}</td>
                     </tr>
                     <tr>
-                        <th>CHRE canonical URL</th>
-                        <td>{% if hoard.chre_url %}<a href="{{ hoard.chre_url }}" target="_blank" rel="noopener noreferrer">{{ hoard.chre_url }}</a>{% else %}-{% endif %}</td>
+                        <th>Source record URL</th>
+                        <td>{% if hoard.source_record_url %}<a href="{{ hoard.source_record_url }}" target="_blank" rel="noopener noreferrer">{{ hoard.source_record_url }}</a>{% else %}-{% endif %}</td>
                     </tr>
                 </table>
 
@@ -286,7 +288,7 @@
                         <td>
                             {% if hoard.polity_mapping_rows %}
                                 {% for row in hoard.polity_mapping_rows %}
-                                    <div>{{ row.overlap_year_from|default:"-" }}</div>
+                                    <div>{{ row.overlap_year_from|default:"-" }}{% if row.temporal_match_basis %} <span class="text-secondary small">({{ row.temporal_match_basis }})</span>{% endif %}</div>
                                 {% endfor %}
                             {% else %}
                                 -

--- a/seshat/apps/core/templates/core/coinhoards/hoard_list.html
+++ b/seshat/apps/core/templates/core/coinhoards/hoard_list.html
@@ -240,19 +240,36 @@
 
     <form method="get" class="mb-3 filter-panel">
         <div class="row g-2 align-items-start">
-            <div class="col-md-4 filter-col">
+            <div class="col-xl-2 col-md-6 filter-col">
                 <label for="filter-q" class="form-label small text-secondary mb-0">Search</label>
                 <input id="filter-q" type="text" class="form-control" name="q" value="{{ q }}" placeholder="ID, name, country">
                 <div class="filter-chip-row">
                     {% if q %}
                         <span class="filter-chip">
                             search: "{{ q }}"
-                            <a class="filter-chip-remove filter-chip-remove-link" href="?start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Remove search filter">x</a>
+                            <a class="filter-chip-remove filter-chip-remove-link" href="?dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Remove search filter">x</a>
                         </span>
                     {% endif %}
                 </div>
             </div>
-            <div class="col-md-4 filter-col">
+            <div class="col-xl-4 col-md-6 filter-col">
+                <label for="filter-dataset" class="form-label small text-secondary mb-0">Dataset</label>
+                <select id="filter-dataset" class="form-select" name="dataset">
+                    <option value="">All datasets</option>
+                    {% for opt in coinhoard_dataset_options %}
+                        <option value="{{ opt.data_source }}" {% if opt.data_source == selected_dataset %}selected{% endif %}>{{ opt.data_source }} ({{ opt.count }})</option>
+                    {% endfor %}
+                </select>
+                <div class="filter-chip-row">
+                    {% if selected_dataset %}
+                        <span class="filter-chip">
+                            {{ selected_dataset }}
+                            <a class="filter-chip-remove filter-chip-remove-link" href="?q={{ q|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Remove dataset filter">x</a>
+                        </span>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="col-xl-3 col-md-6 filter-col">
                 <label for="filter-polity" class="form-label small text-secondary mb-0">Mapped polity</label>
                 <select id="filter-polity" class="form-select" name="polity_picker" title="Select a polity to add as a filter">
                     <option value="">Add a polity filter...</option>
@@ -269,34 +286,38 @@
                     {% for item in selected_polity_items %}
                         <span class="filter-chip">
                             {{ item.label }}
-                            <a class="filter-chip-remove filter-chip-remove-link" href="?q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}{% if pid != item.id %}&polity={{ pid }}{% endif %}{% endfor %}" aria-label="Remove polity filter {{ item.label }}">x</a>
+                            <a class="filter-chip-remove filter-chip-remove-link" href="?q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}{% if pid != item.id %}&polity={{ pid }}{% endif %}{% endfor %}" aria-label="Remove polity filter {{ item.label }}">x</a>
                         </span>
                     {% endfor %}
                 </div>
                 <div class="form-text">Pick one polity at a time; each selection is added right away.</div>
             </div>
-            <div class="col-md-2 filter-col">
-                <label for="filter-start-year" class="form-label small text-secondary mb-0">Start year</label>
-                <input id="filter-start-year" type="number" class="form-control" name="start_year" value="{{ start_year }}" placeholder="Start">
-                <div class="filter-chip-row">
-                    {% if start_year %}
-                        <span class="filter-chip">
-                            start: {{ start_year }}
-                            <a class="filter-chip-remove filter-chip-remove-link" href="?q={{ q }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Remove start year filter">x</a>
-                        </span>
-                    {% endif %}
-                </div>
-            </div>
-            <div class="col-md-2 filter-col">
-                <label for="filter-end-year" class="form-label small text-secondary mb-0">End year</label>
-                <input id="filter-end-year" type="number" class="form-control" name="end_year" value="{{ end_year }}" placeholder="End">
-                <div class="filter-chip-row">
-                    {% if end_year %}
-                        <span class="filter-chip">
-                            end: {{ end_year }}
-                            <a class="filter-chip-remove filter-chip-remove-link" href="?q={{ q }}&start_year={{ start_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Remove end year filter">x</a>
-                        </span>
-                    {% endif %}
+            <div class="col-xl-3 col-md-6 filter-col">
+                <div class="row g-2">
+                    <div class="col-6">
+                        <label for="filter-start-year" class="form-label small text-secondary mb-0">Start year</label>
+                        <input id="filter-start-year" type="number" class="form-control" name="start_year" value="{{ start_year }}" placeholder="Start">
+                        <div class="filter-chip-row">
+                            {% if start_year %}
+                                <span class="filter-chip">
+                                    start: {{ start_year }}
+                                    <a class="filter-chip-remove filter-chip-remove-link" href="?q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Remove start year filter">x</a>
+                                </span>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="col-6">
+                        <label for="filter-end-year" class="form-label small text-secondary mb-0">End year</label>
+                        <input id="filter-end-year" type="number" class="form-control" name="end_year" value="{{ end_year }}" placeholder="End">
+                        <div class="filter-chip-row">
+                            {% if end_year %}
+                                <span class="filter-chip">
+                                    end: {{ end_year }}
+                                    <a class="filter-chip-remove filter-chip-remove-link" href="?q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Remove end year filter">x</a>
+                                </span>
+                            {% endif %}
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -310,6 +331,7 @@
         <summary class="px-3 py-2 fw-semibold" style="cursor:pointer;">Download CSV (filtered results)</summary>
         <form method="get" action="{% url 'coinhoards-export-csv' %}" class="px-3 pb-3 pt-2 border-top" style="border-color:#eadfbe;">
             <input type="hidden" name="q" value="{{ q }}">
+            <input type="hidden" name="dataset" value="{{ selected_dataset }}">
             <input type="hidden" name="start_year" value="{{ start_year }}">
             <input type="hidden" name="end_year" value="{{ end_year }}">
             {% for pid in selected_polity_ids %}
@@ -365,14 +387,14 @@
         <ul class="pagination">
             {% if page_obj.number > 1 %}
                 <li class="page-item">
-                    <a class="page-link" href="?page=1&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="First page">&laquo;&laquo;</a>
+                    <a class="page-link" href="?page=1&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="First page">&laquo;&laquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&laquo;&laquo;</span></li>
             {% endif %}
             {% if page_obj.has_previous %}
                 <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Previous page">&laquo;</a>
+                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Previous page">&laquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
@@ -381,6 +403,7 @@
                 
                 <form method="get" class="jump-form page-link p-1 px-2">
                     <input type="hidden" name="q" value="{{ q }}">
+                    <input type="hidden" name="dataset" value="{{ selected_dataset }}">
                     <input type="hidden" name="start_year" value="{{ start_year }}">
                     <input type="hidden" name="end_year" value="{{ end_year }}">
                     {% for pid in selected_polity_ids %}
@@ -395,14 +418,14 @@
             </li>
             {% if page_obj.has_next %}
                 <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.next_page_number }}&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Next page">&raquo;</a>
+                    <a class="page-link" href="?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Next page">&raquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
             {% endif %}
             {% if page_obj.number < page_obj.paginator.num_pages %}
                 <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Last page">&raquo;&raquo;</a>
+                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Last page">&raquo;&raquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&raquo;&raquo;</span></li>
@@ -442,7 +465,7 @@
                 {% for hoard in page_obj %}
                 <tr>
                     <td class="row-num-cell">{{ page_obj.start_index|add:forloop.counter0 }}</td>
-                    <td><a href="{% url 'coinhoard-detail' hoard.external_dataset_id %}">{{ hoard.external_dataset_id_label }}</a></td>
+                    <td><a href="{% url 'coinhoard-detail' hoard.external_dataset_id %}">{{ hoard.external_dataset_id }}</a></td>
                     <td>{{ hoard.hoard_name|default:"-" }}</td>
                     <td>
                         {% if hoard.mapped_polities %}
@@ -518,14 +541,14 @@
         <ul class="pagination">
             {% if page_obj.number > 1 %}
                 <li class="page-item">
-                    <a class="page-link" href="?page=1&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="First page">&laquo;&laquo;</a>
+                    <a class="page-link" href="?page=1&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="First page">&laquo;&laquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&laquo;&laquo;</span></li>
             {% endif %}
             {% if page_obj.has_previous %}
                 <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Previous page">&laquo;</a>
+                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Previous page">&laquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
@@ -533,6 +556,7 @@
             <li class="page-item">
                 <form method="get" class="jump-form page-link p-1 px-2">
                     <input type="hidden" name="q" value="{{ q }}">
+                    <input type="hidden" name="dataset" value="{{ selected_dataset }}">
                     <input type="hidden" name="start_year" value="{{ start_year }}">
                     <input type="hidden" name="end_year" value="{{ end_year }}">
                     {% for pid in selected_polity_ids %}
@@ -547,14 +571,14 @@
             </li>
             {% if page_obj.has_next %}
                 <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.next_page_number }}&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Next page">&raquo;</a>
+                    <a class="page-link" href="?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Next page">&raquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
             {% endif %}
             {% if page_obj.number < page_obj.paginator.num_pages %}
                 <li class="page-item">
-                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}&q={{ q }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Last page">&raquo;&raquo;</a>
+                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}&q={{ q|urlencode }}&dataset={{ selected_dataset|urlencode }}&start_year={{ start_year }}&end_year={{ end_year }}{% for pid in selected_polity_ids %}&polity={{ pid }}{% endfor %}" aria-label="Last page">&raquo;&raquo;</a>
                 </li>
             {% else %}
                 <li class="page-item disabled"><span class="page-link">&raquo;&raquo;</span></li>

--- a/seshat/apps/core/templates/core/coinhoards/hoard_list.html
+++ b/seshat/apps/core/templates/core/coinhoards/hoard_list.html
@@ -4,7 +4,7 @@
 <style>
     .years-grid {
         display: grid;
-        grid-template-columns: minmax(88px, 1fr);
+        grid-template-columns: minmax(88px, 1fr) 12px minmax(88px, 1fr);
         align-items: center;
         column-gap: 0;
     }
@@ -423,6 +423,8 @@
                         Years
                         <div class="mt-1 text-secondary fw-normal years-grid" style="font-size:0.8rem; border-top:1px dashed #d8d8d8; padding-top:3px;">
                             <span class="cell">Terminal</span>
+                            <span class="sep">|</span>
+                            <span class="cell">Deposit</span>
                         </div>
                     </th>
                     <th class="col-with-left-border">
@@ -440,7 +442,7 @@
                 {% for hoard in page_obj %}
                 <tr>
                     <td class="row-num-cell">{{ page_obj.start_index|add:forloop.counter0 }}</td>
-                    <td><a href="{% url 'coinhoard-detail' hoard.external_dataset_id %}">{{ hoard.external_dataset_id }}</a></td>
+                    <td><a href="{% url 'coinhoard-detail' hoard.external_dataset_id %}">{{ hoard.external_dataset_id_label }}</a></td>
                     <td>{{ hoard.hoard_name|default:"-" }}</td>
                     <td>
                         {% if hoard.mapped_polities %}
@@ -469,21 +471,13 @@
                         <div class="years-grid">
                             <span class="cell">
                                 <span class="badge year-pill">
-                                    {% if hoard.year_from and hoard.year_to %}
-                                        {% if hoard.year_from == hoard.year_to %}
-                                            {% if hoard.year_from < 0 %}<span class="year-num">{{ hoard.year_from|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_from }}</span> <span class="year-era">CE</span>{% endif %}
-                                        {% else %}
-                                            {% if hoard.year_from < 0 %}<span class="year-num">{{ hoard.year_from|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_from }}</span> <span class="year-era">CE</span>{% endif %}
-                                            <span class="year-arrow">&rarr;</span>
-                                            {% if hoard.year_to < 0 %}<span class="year-num">{{ hoard.year_to|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_to }}</span> <span class="year-era">CE</span>{% endif %}
-                                        {% endif %}
-                                    {% elif hoard.year_from %}
-                                        {% if hoard.year_from < 0 %}<span class="year-num">{{ hoard.year_from|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_from }}</span> <span class="year-era">CE</span>{% endif %}
-                                    {% elif hoard.year_to %}
-                                        {% if hoard.year_to < 0 %}<span class="year-num">{{ hoard.year_to|cut:"-" }}</span> <span class="year-era">BCE</span>{% else %}<span class="year-num">{{ hoard.year_to }}</span> <span class="year-era">CE</span>{% endif %}
-                                    {% else %}
-                                        -
-                                    {% endif %}
+                                    {{ hoard.terminal_year_label|default:"-" }}
+                                </span>
+                            </span>
+                            <span class="sep"></span>
+                            <span class="cell">
+                                <span class="badge year-pill">
+                                    {{ hoard.deposit_year_label|default:"-" }}
                                 </span>
                             </span>
                         </div>
@@ -496,17 +490,17 @@
                         </div>
                     </td>
                     <td class="col-with-left-border p-2">
-                        {% if hoard.chre_url %}
-                            <a class="greenlink pe-2" href="{{ hoard.chre_url }}" target="_blank" rel="noopener noreferrer" title="Open CHRE record">
+                        {% if hoard.source_record_url %}
+                            <a class="greenlink pe-2" href="{{ hoard.source_record_url }}" target="_blank" rel="noopener noreferrer" title="Open source record">
                                 <i class="fa-solid fa-up-right-from-square text-primary"></i>
                             </a>
                         {% endif %}
-                        {% if hoard.external_url %}
-                            <a href="{{ hoard.external_url }}" target="_blank" rel="noopener noreferrer" title="Open external source">
+                        {% if hoard.external_url and hoard.external_url != hoard.source_record_url %}
+                            <a href="{{ hoard.external_url }}" target="_blank" rel="noopener noreferrer" title="Open source or dataset">
                                 <i class="fa-solid fa-up-right-from-square text-secondary"></i>
                             </a>
                         {% endif %}
-                        {% if not hoard.chre_url and not hoard.external_url %}
+                        {% if not hoard.source_record_url and not hoard.external_url %}
                             -
                         {% endif %}
                     </td>

--- a/seshat/apps/core/templates/core/polity/polity_detail.html
+++ b/seshat/apps/core/templates/core/polity/polity_detail.html
@@ -572,8 +572,22 @@
         color: #dd571c;
         text-decoration: none;
     }
-    .settlement-link:hover {
+      .settlement-link:hover {
         color: teal;
+    }
+    .coinhoard-section {
+        scroll-margin-top: 1rem;
+        border-top: 1px solid #d8c18a;
+        border-bottom: 1px solid #eadfbe;
+    }
+    .coinhoard-table {
+        min-width: 880px;
+    }
+    .coinhoard-table th {
+        white-space: nowrap;
+    }
+    .coinhoard-location {
+        max-width: 22rem;
     }
 
 </style>
@@ -627,6 +641,12 @@
                     {% if has_any_rt_data %}
                         <a href="#rt_var" class="tight-link" title="Religion Variables">
                             <span class="fs-5 fw-bold" style="border-bottom:3px solid #59007f; background:#59007f22;  padding-left:3px; padding-right:3px; padding-top:2px; color: #59007f;">R</span>
+                        </a>
+                    {% endif %}
+
+                    {% if coinhoard_count %}
+                        <a href="#coin_hoards" class="tight-link" title="Coin Hoards">
+                            <span class="fs-5 fw-bold" style="border-bottom:3px solid #9a6a1f; background:#9a6a1f22; padding-left:3px; padding-right:3px; padding-top:2px; color:#6b470d;">CH</span>
                         </a>
                     {% endif %}
                 
@@ -974,6 +994,62 @@
 
             </div>
             
+            {% endif %}
+
+            {% if coinhoard_count %}
+            <section id="coin_hoards" class="coinhoard-section py-3 my-4">
+                <div class="d-flex flex-wrap justify-content-between align-items-end gap-2 mb-2">
+                    <div>
+                        <h4 class="mb-1" style="color:#6b470d;">Associated Coin Hoards</h4>
+                        <div class="small text-secondary">
+                            {% for source in coinhoard_dataset_counts %}
+                                <span class="d-inline-block me-3"><strong class="text-dark">{{ source.count }}</strong> {{ source.data_source }}</span>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="text-md-end">
+                        {% if coinhoard_has_more %}
+                            <div class="small text-secondary mb-1">Showing {{ associated_coinhoards|length }} of {{ coinhoard_count }}</div>
+                        {% endif %}
+                        <a class="btn btn-sm btn-outline-secondary" href="{% url 'coinhoards' %}?polity={{ object.id }}">
+                            View all {{ coinhoard_count }} <i class="fa-solid fa-arrow-right ms-1"></i>
+                        </a>
+                    </div>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle mb-0 polity-detail-table coinhoard-table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Hoard and location</th>
+                                <th>Dataset</th>
+                                <th class="text-end">Coins</th>
+                                <th>Terminal</th>
+                                <th>Deposit</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for hoard in associated_coinhoards %}
+                            <tr>
+                                <td class="text-nowrap">
+                                    <a class="fw-semibold" href="{% url 'coinhoard-detail' hoard.external_dataset_id %}">{{ hoard.external_dataset_id }}</a>
+                                </td>
+                                <td class="coinhoard-location">
+                                    <div>{{ hoard.hoard_name|default:"Unnamed hoard" }}</div>
+                                    {% if hoard.location_label %}
+                                        <div class="small text-secondary">{{ hoard.location_label }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>{{ hoard.data_source }}</td>
+                                <td class="text-end">{{ hoard.number_of_coins|default_if_none:"-" }}</td>
+                                <td class="text-nowrap">{{ hoard.terminal_year_label|default:"-" }}</td>
+                                <td class="text-nowrap">{{ hoard.deposit_year_label|default:"-" }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
             {% endif %}
 
             

--- a/seshat/apps/core/tests/test_coinhoards.py
+++ b/seshat/apps/core/tests/test_coinhoards.py
@@ -2,20 +2,34 @@ import csv
 import os
 import tempfile
 from collections import defaultdict
+from io import StringIO
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.core.management import call_command
-from django.test import SimpleTestCase, TestCase
+from django.core.management.base import CommandError
+from django.test import RequestFactory, SimpleTestCase, TestCase
 
+from seshat.apps.core.management.commands.import_coinhoards import (
+    MODEL_READY_REQUIRED_COLUMNS,
+)
 from seshat.apps.core.management.commands.map_coinhoards_to_polities import (
     map_coinhoard_to_polities,
 )
 from seshat.apps.core.views_coinhoards import (
-    _external_dataset_id_label,
+    _coinhoard_dataset_choices,
+    _filtered_coinhoard_queryset,
     _format_deposit_date,
     _source_record_url,
+    coinhoard_polity_context,
+    hoard_export_csv,
 )
-from seshat.apps.core.models import Cliopatria, CoinHoard, Polity
+from seshat.apps.core.models import (
+    Cliopatria,
+    CoinHoard,
+    CoinHoardPolityMapping,
+    Polity,
+)
 
 
 class FakeShapeQuerySet(list):
@@ -32,21 +46,7 @@ class CoinHoardImportTests(TestCase):
         try:
             writer = csv.DictWriter(
                 handle,
-                fieldnames=[
-                    "external_dataset_id",
-                    "raw_external_id",
-                    "data_source",
-                    "hoard_name",
-                    "number_of_coins",
-                    "year_from",
-                    "year_to",
-                    "deposit_year_from",
-                    "deposit_year_to",
-                    "deposit_display",
-                    "latitude",
-                    "longitude",
-                    "external_url",
-                ],
+                fieldnames=MODEL_READY_REQUIRED_COLUMNS,
             )
             writer.writeheader()
             writer.writerow(
@@ -80,6 +80,105 @@ class CoinHoardImportTests(TestCase):
         self.assertEqual(hoard.deposit_year_to, 430)
         self.assertEqual(hoard.deposit_display, "425-430 CE")
 
+    def test_incomplete_model_ready_csv_is_rejected_without_erasing_existing_data(self):
+        hoard = CoinHoard.objects.create(
+            seshat_id="900001",
+            external_dataset_id="TEST_EXISTING",
+            data_source="Test dataset",
+            hoard_name="Original name",
+            year_from=400,
+            deposit_year_from=425,
+            latitude="51.5000000",
+            longitude="-0.1000000",
+            summary="Original summary",
+        )
+        handle = tempfile.NamedTemporaryFile("w", newline="", suffix=".csv", delete=False)
+        try:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=["external_dataset_id", "hoard_name"],
+            )
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "external_dataset_id": "TEST_EXISTING",
+                    "hoard_name": "Replacement name",
+                }
+            )
+            handle.close()
+
+            with self.assertRaisesMessage(CommandError, "Model-ready CSV is incomplete"):
+                call_command("import_coinhoards", csv=handle.name, verbosity=0)
+        finally:
+            handle.close()
+            os.unlink(handle.name)
+
+        hoard.refresh_from_db()
+        self.assertEqual(hoard.hoard_name, "Original name")
+        self.assertEqual(hoard.year_from, 400)
+        self.assertEqual(hoard.deposit_year_from, 425)
+        self.assertEqual(hoard.summary, "Original summary")
+
+    def test_legacy_chre_csv_remains_supported(self):
+        handle = tempfile.NamedTemporaryFile("w", newline="", suffix=".csv", delete=False)
+        try:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=["id", "hoardName", "terminalYear1", "terminalYear2"],
+            )
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "id": "7",
+                    "hoardName": "Legacy CHRE hoard",
+                    "terminalYear1": "410",
+                    "terminalYear2": "420",
+                }
+            )
+            handle.close()
+
+            call_command("import_coinhoards", csv=handle.name, verbosity=0)
+        finally:
+            handle.close()
+            os.unlink(handle.name)
+
+        hoard = CoinHoard.objects.get(external_dataset_id="CHRE00007")
+        self.assertEqual(hoard.hoard_name, "Legacy CHRE hoard")
+        self.assertEqual(hoard.year_from, 410)
+        self.assertEqual(hoard.year_to, 420)
+        self.assertIsNone(hoard.deposit_year_from)
+
+    def test_duplicate_model_ready_ids_are_rejected(self):
+        handle = tempfile.NamedTemporaryFile("w", newline="", suffix=".csv", delete=False)
+        try:
+            writer = csv.DictWriter(handle, fieldnames=MODEL_READY_REQUIRED_COLUMNS)
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "external_dataset_id": "TEST_DUPLICATE",
+                    "data_source": "Test dataset",
+                    "hoard_name": "First row",
+                }
+            )
+            writer.writerow(
+                {
+                    "external_dataset_id": "TEST_DUPLICATE",
+                    "data_source": "Test dataset",
+                    "hoard_name": "Second row",
+                }
+            )
+            handle.close()
+
+            with self.assertRaisesMessage(CommandError, "Duplicate external_dataset_id"):
+                call_command("import_coinhoards", csv=handle.name, verbosity=0)
+        finally:
+            handle.close()
+            os.unlink(handle.name)
+
+        self.assertFalse(
+            CoinHoard.objects.filter(external_dataset_id="TEST_DUPLICATE").exists()
+        )
+
 
 class CoinHoardViewHelperTests(SimpleTestCase):
     def test_deposit_date_prefers_normalized_range_over_duplicate_display(self):
@@ -91,15 +190,9 @@ class CoinHoardViewHelperTests(SimpleTestCase):
 
         self.assertEqual(_format_deposit_date(hoard), "931 CE to 945 CE")
 
-    def test_coupland_id_label_removes_internal_separator(self):
-        self.assertEqual(_external_dataset_id_label("COUPLAND_0253"), "COUPLAND0253")
-
-    def test_non_coupland_id_label_is_unchanged(self):
-        self.assertEqual(_external_dataset_id_label("CHRE00253"), "CHRE00253")
-
     def test_source_record_url_is_blank_for_dataset_only_coupland_row(self):
         hoard = CoinHoard(
-            external_dataset_id="COUPLAND_0253",
+            external_dataset_id="COUPLAND0253",
             raw_external_id="253",
             data_source="Coupland Carolingian Hoards",
             external_url="https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/23984&version=1.0",
@@ -121,7 +214,7 @@ class CoinHoardViewHelperTests(SimpleTestCase):
 
     def test_source_record_url_uses_bns_per_hoard_url(self):
         hoard = CoinHoard(
-            external_dataset_id="ENG0735",
+            external_dataset_id="BNSENG0735",
             raw_external_id="ENG0735",
             data_source="British Numismatic Society",
             external_url="https://www.britnumsoc.uk/hoard/ENG0735",
@@ -134,7 +227,7 @@ class CoinHoardViewHelperTests(SimpleTestCase):
 
     def test_source_record_url_uses_coinhoards_org_per_hoard_url(self):
         hoard = CoinHoard(
-            external_dataset_id="IGCH0091",
+            external_dataset_id="CHORGigch0091",
             raw_external_id="igch0091",
             data_source="CoinHoards.org",
             external_url="http://coinhoards.org/id/igch0091",
@@ -143,6 +236,158 @@ class CoinHoardViewHelperTests(SimpleTestCase):
         self.assertEqual(
             _source_record_url(hoard),
             "http://coinhoards.org/id/igch0091",
+        )
+
+
+class CoinHoardDatasetFilterTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        coupland_hoard = CoinHoard.objects.create(
+            seshat_id="990001",
+            external_dataset_id="COUPLAND0253",
+            raw_external_id="253",
+            data_source="Coupland Carolingian Hoards",
+            hoard_name="Coupland test hoard",
+            number_of_coins=70,
+            deposit_year_from=425,
+            deposit_year_to=430,
+            city="Zillis",
+            country="Switzerland",
+        )
+        CoinHoard.objects.create(
+            seshat_id="990002",
+            external_dataset_id="COUPLAND0254",
+            raw_external_id="254",
+            data_source="Coupland Carolingian Hoards",
+            hoard_name="Second Coupland test hoard",
+        )
+        chre_hoard = CoinHoard.objects.create(
+            seshat_id="990003",
+            external_dataset_id="CHRE00253",
+            raw_external_id="253",
+            data_source="Coin Hoards of the Roman Empire",
+            hoard_name="CHRE test hoard",
+            number_of_coins=5,
+            year_from=400,
+            year_to=410,
+            city="Rome",
+            country="Italy",
+        )
+        CoinHoard.objects.create(
+            seshat_id="990004",
+            external_dataset_id="UNSOURCED001",
+            data_source="",
+            hoard_name="Unclassified test hoard",
+        )
+        cls.polity = Polity.objects.create(
+            name="Coin hoard filter test polity",
+            long_name="Coin hoard filter test polity",
+            new_name="coinhoard_filter_test_polity",
+            start_year=350,
+            end_year=500,
+        )
+        CoinHoardPolityMapping.objects.create(
+            coin_hoard=coupland_hoard,
+            polity=cls.polity,
+            overlap_year_from=425,
+            overlap_year_to=430,
+            temporal_match_basis="deposit",
+        )
+        CoinHoardPolityMapping.objects.create(
+            coin_hoard=chre_hoard,
+            polity=cls.polity,
+            overlap_year_from=400,
+            overlap_year_to=410,
+            temporal_match_basis="terminal",
+        )
+
+    def test_dataset_choices_are_dynamic_and_include_record_counts(self):
+        self.assertEqual(
+            _coinhoard_dataset_choices(),
+            [
+                {
+                    "data_source": "Coin Hoards of the Roman Empire",
+                    "count": 1,
+                },
+                {
+                    "data_source": "Coupland Carolingian Hoards",
+                    "count": 2,
+                },
+            ],
+        )
+
+    def test_dataset_filter_selects_exact_source_and_combines_with_search(self):
+        request = RequestFactory().get(
+            "/core/coinhoards/",
+            {
+                "dataset": "Coupland Carolingian Hoards",
+                "q": "0253",
+            },
+        )
+
+        queryset, q, dataset, start, end, polity_ids = _filtered_coinhoard_queryset(
+            request
+        )
+
+        self.assertEqual(
+            list(queryset.values_list("external_dataset_id", flat=True)),
+            ["COUPLAND0253"],
+        )
+        self.assertEqual(q, "0253")
+        self.assertEqual(dataset, "Coupland Carolingian Hoards")
+        self.assertEqual(start, "")
+        self.assertEqual(end, "")
+        self.assertEqual(polity_ids, [])
+
+    def test_polity_context_summarizes_and_caps_associated_hoards(self):
+        context = coinhoard_polity_context(self.polity.id, preview_limit=1)
+
+        self.assertEqual(context["coinhoard_count"], 2)
+        self.assertTrue(context["coinhoard_has_more"])
+        self.assertEqual(
+            context["coinhoard_dataset_counts"],
+            [
+                {
+                    "data_source": "Coin Hoards of the Roman Empire",
+                    "count": 1,
+                },
+                {
+                    "data_source": "Coupland Carolingian Hoards",
+                    "count": 1,
+                },
+            ],
+        )
+        self.assertEqual(len(context["associated_coinhoards"]), 1)
+        hoard = context["associated_coinhoards"][0]
+        self.assertEqual(hoard.external_dataset_id, "CHRE00253")
+        self.assertEqual(hoard.location_label, "Rome, Italy")
+        self.assertEqual(hoard.terminal_year_label, "400 CE to 410 CE")
+        self.assertEqual(hoard.deposit_year_label, "")
+
+    def test_csv_export_applies_dataset_and_polity_filters(self):
+        request = RequestFactory().get(
+            "/core/coinhoards/export/",
+            {
+                "dataset": "Coupland Carolingian Hoards",
+                "polity": str(self.polity.id),
+                "col": ["external_dataset_id", "number_of_coins", "data_source"],
+                "delimiter": "comma",
+            },
+        )
+        request.user = SimpleNamespace(is_authenticated=True)
+
+        response = hoard_export_csv(request)
+        rows = list(csv.reader(StringIO(response.content.decode("utf-8-sig"))))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response["Content-Type"].startswith("text/csv"))
+        self.assertIn("coinhoards_export_", response["Content-Disposition"])
+        self.assertEqual(
+            rows,
+            [
+                ["External dataset ID", "Number of coins", "Data source"],
+                ["COUPLAND0253", "70", "Coupland Carolingian Hoards"],
+            ],
         )
 
 

--- a/seshat/apps/core/tests/test_coinhoards.py
+++ b/seshat/apps/core/tests/test_coinhoards.py
@@ -1,0 +1,249 @@
+import csv
+import os
+import tempfile
+from collections import defaultdict
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase
+
+from seshat.apps.core.management.commands.map_coinhoards_to_polities import (
+    map_coinhoard_to_polities,
+)
+from seshat.apps.core.views_coinhoards import (
+    _external_dataset_id_label,
+    _format_deposit_date,
+    _source_record_url,
+)
+from seshat.apps.core.models import Cliopatria, CoinHoard, Polity
+
+
+class FakeShapeQuerySet(list):
+    def only(self, *args):
+        return self
+
+    def order_by(self, *args):
+        return self
+
+
+class CoinHoardImportTests(TestCase):
+    def test_model_ready_csv_import_keeps_terminal_and_deposit_dates_separate(self):
+        handle = tempfile.NamedTemporaryFile("w", newline="", suffix=".csv", delete=False)
+        try:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=[
+                    "external_dataset_id",
+                    "raw_external_id",
+                    "data_source",
+                    "hoard_name",
+                    "number_of_coins",
+                    "year_from",
+                    "year_to",
+                    "deposit_year_from",
+                    "deposit_year_to",
+                    "deposit_display",
+                    "latitude",
+                    "longitude",
+                    "external_url",
+                ],
+            )
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "external_dataset_id": "TEST001",
+                    "raw_external_id": "raw-1",
+                    "data_source": "Test dataset",
+                    "hoard_name": "Test hoard",
+                    "number_of_coins": "12",
+                    "year_from": "400",
+                    "year_to": "410",
+                    "deposit_year_from": "425",
+                    "deposit_year_to": "430",
+                    "deposit_display": "425-430 CE",
+                    "latitude": "51.5",
+                    "longitude": "-0.1",
+                    "external_url": "https://example.test/hoard/1",
+                }
+            )
+            handle.close()
+
+            call_command("import_coinhoards", csv=handle.name, verbosity=0)
+        finally:
+            handle.close()
+            os.unlink(handle.name)
+
+        hoard = CoinHoard.objects.get(external_dataset_id="TEST001")
+        self.assertEqual(hoard.year_from, 400)
+        self.assertEqual(hoard.year_to, 410)
+        self.assertEqual(hoard.deposit_year_from, 425)
+        self.assertEqual(hoard.deposit_year_to, 430)
+        self.assertEqual(hoard.deposit_display, "425-430 CE")
+
+
+class CoinHoardViewHelperTests(SimpleTestCase):
+    def test_deposit_date_prefers_normalized_range_over_duplicate_display(self):
+        hoard = CoinHoard(
+            deposit_year_from=931,
+            deposit_year_to=945,
+            deposit_display="931–945",
+        )
+
+        self.assertEqual(_format_deposit_date(hoard), "931 CE to 945 CE")
+
+    def test_coupland_id_label_removes_internal_separator(self):
+        self.assertEqual(_external_dataset_id_label("COUPLAND_0253"), "COUPLAND0253")
+
+    def test_non_coupland_id_label_is_unchanged(self):
+        self.assertEqual(_external_dataset_id_label("CHRE00253"), "CHRE00253")
+
+    def test_source_record_url_is_blank_for_dataset_only_coupland_row(self):
+        hoard = CoinHoard(
+            external_dataset_id="COUPLAND_0253",
+            raw_external_id="253",
+            data_source="Coupland Carolingian Hoards",
+            external_url="https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/23984&version=1.0",
+        )
+
+        self.assertEqual(_source_record_url(hoard), "")
+
+    def test_source_record_url_is_built_for_chre_rows(self):
+        hoard = CoinHoard(
+            external_dataset_id="CHRE00253",
+            raw_external_id="253",
+            data_source="Coin Hoards of the Roman Empire",
+        )
+
+        self.assertEqual(
+            _source_record_url(hoard),
+            "https://chre.ashmus.ox.ac.uk/hoard/253",
+        )
+
+    def test_source_record_url_uses_bns_per_hoard_url(self):
+        hoard = CoinHoard(
+            external_dataset_id="ENG0735",
+            raw_external_id="ENG0735",
+            data_source="British Numismatic Society",
+            external_url="https://www.britnumsoc.uk/hoard/ENG0735",
+        )
+
+        self.assertEqual(
+            _source_record_url(hoard),
+            "https://www.britnumsoc.uk/hoard/ENG0735",
+        )
+
+    def test_source_record_url_uses_coinhoards_org_per_hoard_url(self):
+        hoard = CoinHoard(
+            external_dataset_id="IGCH0091",
+            raw_external_id="igch0091",
+            data_source="CoinHoards.org",
+            external_url="http://coinhoards.org/id/igch0091",
+        )
+
+        self.assertEqual(
+            _source_record_url(hoard),
+            "http://coinhoards.org/id/igch0091",
+        )
+
+
+class CoinHoardPolityMappingTests(SimpleTestCase):
+    def setUp(self):
+        self.polity = Polity(
+            id=1,
+            name="Test polity",
+            long_name="Test polity",
+            new_name="test_polity",
+            start_year=400,
+            end_year=700,
+        )
+        self.shape = Cliopatria(
+            id=1,
+            name="Test shape",
+            seshat_id="test_polity",
+            area=1.0,
+            start_year=400,
+            end_year=700,
+            polity_start_year=400,
+            polity_end_year=700,
+            colour="#FFFFFF",
+            components="",
+            member_of="",
+            wikipedia_name="",
+        )
+
+    def test_mapping_uses_deposit_date(self):
+        hoard = CoinHoard(
+            id=1,
+            seshat_id="900001",
+            external_dataset_id="TEST002",
+            data_source="Test dataset",
+            hoard_name="Deposit-only hoard",
+            latitude=0.5,
+            longitude=0.5,
+            deposit_year_from=550,
+            deposit_year_to=560,
+        )
+
+        with patch(
+            "seshat.apps.core.management.commands.map_coinhoards_to_polities.Cliopatria.objects.filter",
+            return_value=FakeShapeQuerySet([self.shape]),
+        ):
+            mappings = map_coinhoard_to_polities(
+                hoard,
+                defaultdict(list, {"test_polity": [self.polity]}),
+            )
+
+        self.assertEqual(len(mappings), 1)
+        self.assertEqual(mappings[0].overlap_year_from, 550)
+        self.assertEqual(mappings[0].temporal_match_basis, "deposit")
+
+    def test_mapping_prefers_deposit_date_when_both_dates_exist(self):
+        hoard = CoinHoard(
+            id=2,
+            seshat_id="900002",
+            external_dataset_id="TEST003",
+            data_source="Test dataset",
+            hoard_name="Terminal hoard",
+            latitude=0.5,
+            longitude=0.5,
+            year_from=450,
+            deposit_year_from=550,
+        )
+
+        with patch(
+            "seshat.apps.core.management.commands.map_coinhoards_to_polities.Cliopatria.objects.filter",
+            return_value=FakeShapeQuerySet([self.shape]),
+        ):
+            mappings = map_coinhoard_to_polities(
+                hoard,
+                defaultdict(list, {"test_polity": [self.polity]}),
+            )
+
+        self.assertEqual(len(mappings), 1)
+        self.assertEqual(mappings[0].overlap_year_from, 550)
+        self.assertEqual(mappings[0].temporal_match_basis, "deposit")
+
+    def test_mapping_falls_back_to_terminal_date_when_deposit_date_missing(self):
+        hoard = CoinHoard(
+            id=3,
+            seshat_id="900003",
+            external_dataset_id="TEST004",
+            data_source="Test dataset",
+            hoard_name="Terminal-only hoard",
+            latitude=0.5,
+            longitude=0.5,
+            year_from=450,
+        )
+
+        with patch(
+            "seshat.apps.core.management.commands.map_coinhoards_to_polities.Cliopatria.objects.filter",
+            return_value=FakeShapeQuerySet([self.shape]),
+        ):
+            mappings = map_coinhoard_to_polities(
+                hoard,
+                defaultdict(list, {"test_polity": [self.polity]}),
+            )
+
+        self.assertEqual(len(mappings), 1)
+        self.assertEqual(mappings[0].overlap_year_from, 450)
+        self.assertEqual(mappings[0].temporal_match_basis, "terminal_fallback")

--- a/seshat/apps/core/tests/test_coinhoards.py
+++ b/seshat/apps/core/tests/test_coinhoards.py
@@ -225,6 +225,19 @@ class CoinHoardViewHelperTests(SimpleTestCase):
             "https://www.britnumsoc.uk/hoard/ENG0735",
         )
 
+    def test_source_record_url_builds_bns_url_from_raw_id(self):
+        hoard = CoinHoard(
+            external_dataset_id="BNSCY0137",
+            raw_external_id="CY0137",
+            data_source="British Numismatic Society",
+            external_url="https://www.britnumsoc.org/mchbi",
+        )
+
+        self.assertEqual(
+            _source_record_url(hoard),
+            "https://www.britnumsoc.uk/hoard/CY0137",
+        )
+
     def test_source_record_url_uses_coinhoards_org_per_hoard_url(self):
         hoard = CoinHoard(
             external_dataset_id="CHORGigch0091",
@@ -236,6 +249,19 @@ class CoinHoardViewHelperTests(SimpleTestCase):
         self.assertEqual(
             _source_record_url(hoard),
             "http://coinhoards.org/id/igch0091",
+        )
+
+    def test_source_record_url_builds_coinhoards_org_url_from_raw_id(self):
+        hoard = CoinHoard(
+            external_dataset_id="CHORGCHANGE0006",
+            raw_external_id="change.0006",
+            data_source="CoinHoards.org",
+            external_url="http://coinhoards.org/",
+        )
+
+        self.assertEqual(
+            _source_record_url(hoard),
+            "http://coinhoards.org/id/change.0006",
         )
 
 

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -86,6 +86,7 @@ from ..crisisdb.instability_filters import (
 )
 
 from .models import Citation, Polity, Section, Subsection, Variablehierarchy, Reference, SeshatComment, SeshatCommentPart, Nga, Ngapolityrel, Capital, Seshat_region, Macro_region, Cliopatria, GADMCountries, GADMProvinces, SeshatCommon, ScpThroughCtn, SeshatPrivateComment, SeshatPrivateCommentPart, Religion, HabitationSite, CityPolityRelation
+from .views_coinhoards import coinhoard_polity_context
 
 import pprint
 import requests
@@ -3114,6 +3115,16 @@ class PolityDetailView(SuccessMessageMixin, generic.DetailView):
         context["selected_instability_source"] = selected_instability_source
         context["show_instability_source_filter"] = bool(selected_instability_source)
         context["show_instability_batch_filter"] = bool(selected_instability_batch)
+        context.update(
+            {
+                "associated_coinhoards": [],
+                "coinhoard_count": 0,
+                "coinhoard_dataset_counts": [],
+                "coinhoard_has_more": False,
+            }
+        )
+        if self.request.user.is_authenticated:
+            context.update(coinhoard_polity_context(self.object.pk))
         try:
             context["all_data"] = get_all_data_for_a_polity(self.object.pk, "crisisdb") 
             context["all_general_data"], context["has_any_general_data"] = get_all_general_data_for_a_polity(self.object.pk)

--- a/seshat/apps/core/views_coinhoards.py
+++ b/seshat/apps/core/views_coinhoards.py
@@ -13,6 +13,8 @@ from django.utils import timezone
 from .models import CoinHoard, CoinHoardPolityMapping, Polity
 
 CHRE_BASE_URL = "https://chre.ashmus.ox.ac.uk/hoard/"
+BNS_RECORD_BASE_URL = "https://www.britnumsoc.uk/hoard/"
+COINHOARDS_ORG_RECORD_BASE_URL = "http://coinhoards.org/id/"
 CHRE_DATA_SOURCE = "Coin Hoards of the Roman Empire"
 BNS_DATA_SOURCE = "British Numismatic Society"
 COINHOARDS_ORG_DATA_SOURCE = "CoinHoards.org"
@@ -55,6 +57,10 @@ def _source_record_url_from_parts(
     raw_id = str(raw_external_id or "").strip()
     if source == CHRE_DATA_SOURCE and raw_id.isdigit():
         return f"{CHRE_BASE_URL}{int(raw_id)}"
+    if source == BNS_DATA_SOURCE and raw_id:
+        return f"{BNS_RECORD_BASE_URL}{raw_id}"
+    if source == COINHOARDS_ORG_DATA_SOURCE and raw_id:
+        return f"{COINHOARDS_ORG_RECORD_BASE_URL}{raw_id}"
     return ""
 
 

--- a/seshat/apps/core/views_coinhoards.py
+++ b/seshat/apps/core/views_coinhoards.py
@@ -13,6 +13,9 @@ from django.utils import timezone
 from .models import CoinHoard, CoinHoardPolityMapping, Polity
 
 CHRE_BASE_URL = "https://chre.ashmus.ox.ac.uk/hoard/"
+CHRE_DATA_SOURCE = "Coin Hoards of the Roman Empire"
+BNS_DATA_SOURCE = "British Numismatic Society"
+COINHOARDS_ORG_DATA_SOURCE = "CoinHoards.org"
 RATING_MAP = {
     "1": ("poor", "rating-poor"),
     "2": ("fair", "rating-fair"),
@@ -25,15 +28,43 @@ def _rating_meta(value):
     return RATING_MAP.get(str(value or "").strip(), ("-", "rating-empty"))
 
 
-def _chre_url(hoard):
-    raw_id = str(hoard.raw_external_id or "").strip()
-    if raw_id.isdigit():
-        return f"{CHRE_BASE_URL}{int(raw_id)}"
+def _is_direct_external_record_url(data_source, external_url):
+    source = str(data_source or "").strip()
+    url = str(external_url or "").strip()
+    if source == BNS_DATA_SOURCE:
+        return "britnumsoc.uk/hoard/" in url
+    if source == COINHOARDS_ORG_DATA_SOURCE:
+        return "coinhoards.org/id/" in url
+    return False
 
-    ext = str(hoard.external_dataset_id or "").strip().upper()
+
+def _source_record_url_from_parts(
+    data_source,
+    raw_external_id,
+    external_dataset_id,
+    external_url,
+):
+    ext = str(external_dataset_id or "").strip().upper()
     if ext.startswith("CHRE") and ext[4:].isdigit():
         return f"{CHRE_BASE_URL}{int(ext[4:])}"
+
+    source = str(data_source or "").strip()
+    if _is_direct_external_record_url(source, external_url):
+        return str(external_url or "").strip()
+
+    raw_id = str(raw_external_id or "").strip()
+    if source == CHRE_DATA_SOURCE and raw_id.isdigit():
+        return f"{CHRE_BASE_URL}{int(raw_id)}"
     return ""
+
+
+def _source_record_url(hoard):
+    return _source_record_url_from_parts(
+        hoard.data_source,
+        hoard.raw_external_id,
+        hoard.external_dataset_id,
+        hoard.external_url,
+    )
 
 
 COINHOARD_CSV_COLUMN_GROUPS = (
@@ -66,6 +97,9 @@ COINHOARD_CSV_COLUMN_GROUPS = (
         (
             ("year_from", "Terminal year (from)"),
             ("year_to", "Terminal year (to)"),
+            ("deposit_year_from", "Deposit year (from)"),
+            ("deposit_year_to", "Deposit year (to)"),
+            ("deposit_display", "Deposit date display"),
             ("opening_year1", "Opening year (from)"),
             ("opening_year2", "Opening year (to)"),
             ("discovery_year1", "Discovery year (from)"),
@@ -90,7 +124,7 @@ COINHOARD_CSV_COLUMN_GROUPS = (
             ("summary", "Summary"),
             ("external_source_text", "External source text"),
             ("external_url", "External URL"),
-            ("chre_url", "CHRE URL"),
+            ("source_record_url", "Source record URL"),
         ),
     ),
     (
@@ -150,13 +184,74 @@ COINHOARD_CSV_DEFAULT_COLS = (
     "number_of_coins",
     "year_from",
     "year_to",
+    "deposit_year_from",
+    "deposit_year_to",
     "latitude",
     "longitude",
     "region",
     "country",
-    "chre_url",
+    "source_record_url",
     "external_url",
 )
+
+
+def _format_year(value):
+    if value is None:
+        return ""
+    return f"{abs(value)} BCE" if value < 0 else f"{value} CE"
+
+
+def _format_year_range(start, end):
+    if start is None and end is None:
+        return ""
+    if start is None:
+        return _format_year(end)
+    if end is None or start == end:
+        return _format_year(start)
+    return f"{_format_year(start)} to {_format_year(end)}"
+
+
+def _format_deposit_date(hoard):
+    range_text = _format_year_range(hoard.deposit_year_from, hoard.deposit_year_to)
+    display = (hoard.deposit_display or "").strip()
+    return range_text or display
+
+
+def _external_dataset_id_label(value):
+    value = str(value or "").strip()
+    if value.startswith("COUPLAND_") and value.removeprefix("COUPLAND_").isdigit():
+        return value.replace("COUPLAND_", "COUPLAND", 1)
+    return value
+
+
+def _has_terminal_date_q():
+    return Q(year_from__isnull=False) | Q(year_to__isnull=False)
+
+
+def _has_deposit_date_q():
+    return Q(deposit_year_from__isnull=False) | Q(deposit_year_to__isnull=False)
+
+
+def _range_end_gte_q(start_field, end_field, value):
+    return Q(**{f"{end_field}__gte": value}) | (
+        Q(**{f"{end_field}__isnull": True}) & Q(**{f"{start_field}__gte": value})
+    )
+
+
+def _range_start_lte_q(start_field, end_field, value):
+    return Q(**{f"{start_field}__lte": value}) | (
+        Q(**{f"{start_field}__isnull": True}) & Q(**{f"{end_field}__lte": value})
+    )
+
+
+def _temporal_filter_q(predicate):
+    has_terminal = _has_terminal_date_q()
+    deposit_fallback = ~has_terminal & _has_deposit_date_q()
+    return (
+        has_terminal & predicate("year_from", "year_to")
+    ) | (
+        deposit_fallback & predicate("deposit_year_from", "deposit_year_to")
+    )
 
 
 def _filtered_coinhoard_queryset(request):
@@ -176,10 +271,22 @@ def _filtered_coinhoard_queryset(request):
     try:
         if start:
             start_int = int(start)
-            queryset = queryset.filter(Q(year_to__isnull=True) | Q(year_to__gte=start_int))
+            queryset = queryset.filter(
+                _temporal_filter_q(
+                    lambda start_field, end_field: _range_end_gte_q(
+                        start_field, end_field, start_int
+                    )
+                )
+            )
         if end:
             end_int = int(end)
-            queryset = queryset.filter(Q(year_from__isnull=True) | Q(year_from__lte=end_int))
+            queryset = queryset.filter(
+                _temporal_filter_q(
+                    lambda start_field, end_field: _range_start_lte_q(
+                        start_field, end_field, end_int
+                    )
+                )
+            )
     except ValueError:
         pass
 
@@ -205,8 +312,8 @@ def _mapped_polities_export_text(hoard):
 
 
 def _coinhoard_csv_cell_value(hoard, key):
-    if key == "chre_url":
-        return _chre_url(hoard)
+    if key == "source_record_url":
+        return _source_record_url(hoard)
     if key == "mapped_polities":
         return _mapped_polities_export_text(hoard)
     value = getattr(hoard, key)
@@ -247,7 +354,10 @@ def hoard_list(request):
         hoard.findspot_label, hoard.findspot_class = _rating_meta(hoard.find_spot_rating)
         hoard.context_label, hoard.context_class = _rating_meta(hoard.contextual_rating)
         hoard.numismatic_label, hoard.numismatic_class = _rating_meta(hoard.numismatic_rating)
-        hoard.chre_url = _chre_url(hoard)
+        hoard.source_record_url = _source_record_url(hoard)
+        hoard.terminal_year_label = _format_year_range(hoard.year_from, hoard.year_to)
+        hoard.deposit_year_label = _format_deposit_date(hoard)
+        hoard.external_dataset_id_label = _external_dataset_id_label(hoard.external_dataset_id)
         seen_polity_ids = set()
         hoard.mapped_polities = []
         for mapping in hoard.polity_mappings.all():
@@ -332,10 +442,12 @@ def hoard_detail(request, external_dataset_id):
         ),
         external_dataset_id=external_dataset_id,
     )
-    hoard.chre_url = _chre_url(hoard)
+    hoard.source_record_url = _source_record_url(hoard)
+    hoard.external_dataset_id_label = _external_dataset_id_label(hoard.external_dataset_id)
     hoard.findspot_label, hoard.findspot_class = _rating_meta(hoard.find_spot_rating)
     hoard.context_label, hoard.context_class = _rating_meta(hoard.contextual_rating)
     hoard.numismatic_label, hoard.numismatic_class = _rating_meta(hoard.numismatic_rating)
+    hoard.deposit_year_label = _format_deposit_date(hoard)
     hoard.polity_mapping_rows = []
     for mapping in hoard.polity_mappings.all():
         polity_name = (mapping.polity.long_name or mapping.polity.name or "").strip() or "-"
@@ -351,6 +463,7 @@ def hoard_detail(request, external_dataset_id):
                 "polity_year_to": mapping.polity.end_year,
                 "overlap_year_from": mapping.overlap_year_from,
                 "overlap_year_to": mapping.overlap_year_to,
+                "temporal_match_basis": mapping.temporal_match_basis,
                 "shape_name": shape_name,
             }
         )
@@ -363,12 +476,16 @@ def hoard_list_json(request):
         CoinHoard.objects.values(
             "external_dataset_id",
             "raw_external_id",
+            "data_source",
             "hoard_name",
             "number_of_coins",
             "opening_year1",
             "opening_year2",
             "year_from",
             "year_to",
+            "deposit_year_from",
+            "deposit_year_to",
+            "deposit_display",
             "latitude",
             "longitude",
             "region",
@@ -378,10 +495,10 @@ def hoard_list_json(request):
         )[:500]
     )
     for row in rows:
-        raw_id = str(row.get("raw_external_id") or "").strip()
-        if raw_id.isdigit():
-            row["chre_url"] = f"{CHRE_BASE_URL}{int(raw_id)}"
-        else:
-            ext = str(row.get("external_dataset_id") or "").strip().upper()
-            row["chre_url"] = f"{CHRE_BASE_URL}{int(ext[4:])}" if ext.startswith("CHRE") and ext[4:].isdigit() else ""
+        row["source_record_url"] = _source_record_url_from_parts(
+            row.get("data_source"),
+            row.get("raw_external_id"),
+            row.get("external_dataset_id"),
+            row.get("external_url"),
+        )
     return JsonResponse({"count": len(rows), "results": rows})

--- a/seshat/apps/core/views_coinhoards.py
+++ b/seshat/apps/core/views_coinhoards.py
@@ -5,7 +5,7 @@ from io import StringIO
 
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
-from django.db.models import Prefetch, Q, prefetch_related_objects
+from django.db.models import Count, Prefetch, Q, prefetch_related_objects
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
@@ -164,6 +164,16 @@ def _coinhoard_mapped_polity_choices():
     return [{"id": p.id, "label": _coinhoard_mapped_polity_label(p)} for p in polities]
 
 
+def _coinhoard_dataset_choices():
+    return list(
+        CoinHoard.objects.exclude(data_source="")
+        .exclude(data_source__isnull=True)
+        .values("data_source")
+        .annotate(count=Count("id"))
+        .order_by("data_source")
+    )
+
+
 def _valid_selected_polity_ids(request):
     raw_ids = request.GET.getlist("polity")
     unique_ids = []
@@ -194,6 +204,8 @@ COINHOARD_CSV_DEFAULT_COLS = (
     "external_url",
 )
 
+POLITY_COINHOARD_PREVIEW_LIMIT = 10
+
 
 def _format_year(value):
     if value is None:
@@ -217,11 +229,52 @@ def _format_deposit_date(hoard):
     return range_text or display
 
 
-def _external_dataset_id_label(value):
-    value = str(value or "").strip()
-    if value.startswith("COUPLAND_") and value.removeprefix("COUPLAND_").isdigit():
-        return value.replace("COUPLAND_", "COUPLAND", 1)
-    return value
+def _coinhoard_location_label(hoard):
+    parts = []
+    seen = set()
+    for value in (hoard.city, hoard.county, hoard.region, hoard.country):
+        part = str(value or "").strip()
+        normalized = part.casefold()
+        if part and normalized not in seen:
+            seen.add(normalized)
+            parts.append(part)
+    if parts:
+        return ", ".join(parts)
+    if hoard.latitude is not None and hoard.longitude is not None:
+        return f"{hoard.latitude:.3f}, {hoard.longitude:.3f}"
+    return ""
+
+
+def coinhoard_polity_context(polity_id, preview_limit=POLITY_COINHOARD_PREVIEW_LIMIT):
+    queryset = CoinHoard.objects.filter(
+        polity_mappings__polity_id=polity_id
+    ).distinct()
+    count = queryset.count()
+    context = {
+        "associated_coinhoards": [],
+        "coinhoard_count": count,
+        "coinhoard_dataset_counts": [],
+        "coinhoard_has_more": False,
+    }
+    if not count:
+        return context
+
+    context["coinhoard_dataset_counts"] = list(
+        CoinHoard.objects.filter(polity_mappings__polity_id=polity_id)
+        .order_by()
+        .values("data_source")
+        .annotate(count=Count("id", distinct=True))
+        .order_by("data_source")
+    )
+    hoards = list(queryset.order_by("external_dataset_id")[:preview_limit])
+    for hoard in hoards:
+        hoard.location_label = _coinhoard_location_label(hoard)
+        hoard.terminal_year_label = _format_year_range(hoard.year_from, hoard.year_to)
+        hoard.deposit_year_label = _format_deposit_date(hoard)
+
+    context["associated_coinhoards"] = hoards
+    context["coinhoard_has_more"] = count > len(hoards)
+    return context
 
 
 def _has_terminal_date_q():
@@ -256,6 +309,7 @@ def _temporal_filter_q(predicate):
 
 def _filtered_coinhoard_queryset(request):
     q = request.GET.get("q", "").strip()
+    dataset = request.GET.get("dataset", "").strip()
     start = request.GET.get("start_year", "").strip()
     end = request.GET.get("end_year", "").strip()
 
@@ -267,6 +321,9 @@ def _filtered_coinhoard_queryset(request):
             | Q(hoard_name__icontains=q)
             | Q(country__icontains=q)
         )
+
+    if dataset:
+        queryset = queryset.filter(data_source=dataset)
 
     try:
         if start:
@@ -294,7 +351,7 @@ def _filtered_coinhoard_queryset(request):
     if selected_polity_ids:
         queryset = queryset.filter(polity_mappings__polity_id__in=selected_polity_ids).distinct()
 
-    return queryset, q, start, end, selected_polity_ids
+    return queryset, q, dataset, start, end, selected_polity_ids
 
 
 def _mapped_polities_export_text(hoard):
@@ -328,7 +385,10 @@ def _coinhoard_csv_cell_value(hoard, key):
 
 @login_required
 def hoard_list(request):
-    queryset, q, start, end, selected_polity_ids = _filtered_coinhoard_queryset(request)
+    queryset, q, dataset, start, end, selected_polity_ids = _filtered_coinhoard_queryset(
+        request
+    )
+    dataset_options = _coinhoard_dataset_choices()
     polity_options = _coinhoard_mapped_polity_choices()
     polity_label_by_id = {str(item["id"]): item["label"] for item in polity_options}
     selected_polity_items = [
@@ -357,7 +417,6 @@ def hoard_list(request):
         hoard.source_record_url = _source_record_url(hoard)
         hoard.terminal_year_label = _format_year_range(hoard.year_from, hoard.year_to)
         hoard.deposit_year_label = _format_deposit_date(hoard)
-        hoard.external_dataset_id_label = _external_dataset_id_label(hoard.external_dataset_id)
         seen_polity_ids = set()
         hoard.mapped_polities = []
         for mapping in hoard.polity_mappings.all():
@@ -377,6 +436,8 @@ def hoard_list(request):
         {
             "page_obj": page_obj,
             "q": q,
+            "selected_dataset": dataset,
+            "coinhoard_dataset_options": dataset_options,
             "start_year": start,
             "end_year": end,
             "selected_polity_ids": selected_polity_ids,
@@ -443,7 +504,6 @@ def hoard_detail(request, external_dataset_id):
         external_dataset_id=external_dataset_id,
     )
     hoard.source_record_url = _source_record_url(hoard)
-    hoard.external_dataset_id_label = _external_dataset_id_label(hoard.external_dataset_id)
     hoard.findspot_label, hoard.findspot_class = _rating_meta(hoard.find_spot_rating)
     hoard.context_label, hoard.context_class = _rating_meta(hoard.contextual_rating)
     hoard.numismatic_label, hoard.numismatic_class = _rating_meta(hoard.numismatic_rating)


### PR DESCRIPTION
## Summary

- Add separate deposition chronology fields to coin hoards.
- Preserve `year_from` and `year_to` as terminal coin chronology.
- Prefer deposition chronology for polity matching, with terminal chronology as fallback.
- Add dataset and polity filtering and configurable CSV exports.
- Display associated coin hoards on polity pages.



## Validation

- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test seshat.apps.core.tests.test_coinhoards --keepdb`
- All 18 coin-hoard tests pass.
- All 7,903 prepared records were verified against the local database.