### PR TITLE
Update Seshat data license to CC BY-SA 4.0

### DIFF
--- a/seshat/apps/accounts/migrations/0017_publish_cc_by_sa_4_terms.py
+++ b/seshat/apps/accounts/migrations/0017_publish_cc_by_sa_4_terms.py
@@ -1,0 +1,125 @@
+from django.db import migrations
+
+
+AGREEMENT_SLUG = "seshat-user-agreement-2026-07-14-cc-by-sa-4-0"
+AGREEMENT_TITLE = "Seshat Databank — User Agreement"
+AGREEMENT_BODY_HTML = """
+<div style="font-size:12px">
+  <h4>Seshat Databank — User Agreement</h4>
+
+  <h5>1) Introduction</h5>
+  <p>By using the Seshat Databank (“<strong>Seshat</strong>,” “<strong>we</strong>,” “<strong>us</strong>”), you (“<strong>User</strong>”) agree to this User Agreement. If you do not agree, do not create an account, download data, or use the API.</p>
+
+  <h5>2) Scope &amp; Definitions</h5>
+  <ul>
+    <li><strong>Public Data:</strong> Datasets released in connection with Seshat publications or curated public releases.</li>
+    <li><strong>Private Data:</strong> Work-in-progress datasets under review/cleaning or otherwise not publicly released.</li>
+    <li><strong>Download Formats:</strong> CSV and JSON files available from the website or programmatic endpoints.</li>
+    <li><strong>Current Terms:</strong> The active Terms &amp; Conditions version shown on the site.</li>
+  </ul>
+
+  <h5>3) Access &amp; Accounts</h5>
+  <ul>
+    <li><strong>Browse without an account:</strong> You may browse public pages without signing in.</li>
+    <li><strong>Account required to download:</strong> To download Public Data (CSV/JSON), you must create a free account and consent to the Current Terms.</li>
+    <li><strong>Google sign-in:</strong> If you sign in with Google (or any SSO), you must accept the Current Terms on your first logged-in visit before continuing.</li>
+    <li><strong>Existing users:</strong> If you have an account but have not accepted the Current Terms, you will be prompted to accept them before continuing (excluding the landing page and API).</li>
+  </ul>
+
+  <h5>4) Consent, Logging, and Re-consent</h5>
+  <ul>
+    <li><strong>Consent record:</strong> When you accept the Terms, we log the terms version, timestamp, IP address, and user agent for audit.</li>
+    <li><strong>One-time per version:</strong> You won’t be prompted again for the same version.</li>
+    <li><strong>When terms change:</strong> If we publish new terms, you’ll be prompted to accept the new version on your next visit before continuing (and before any download).</li>
+  </ul>
+
+  <h5>5) Data Categories &amp; Restrictions</h5>
+  <ul>
+    <li><strong>Public Data:</strong> Can be viewed by anyone and downloaded by registered users who have accepted the Terms. Licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license">Creative Commons Attribution–ShareAlike 4.0 International License (CC BY-SA 4.0)</a>.</li>
+    <li><strong>Private Data:</strong> May be visible in parts of the interface for transparency to collaborators but is <strong>not downloadable</strong> and must <strong>not</strong> be shared or published. You may submit feedback and sources via private comments where available.</li>
+  </ul>
+
+  <h5>6) License (Public Data)</h5>
+  <p>Public Data is provided under <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license"><strong>CC BY-SA 4.0</strong></a>: you may share and adapt the Public Data, including for commercial purposes, provided that you give appropriate attribution, include a link to the license, and indicate whether changes were made. If you remix, transform, or build upon the Public Data, you must distribute your contributions under the same license or a license that Creative Commons has declared compatible.</p>
+  <p><strong>Required citation text in publications (example):</strong></p>
+  <blockquote>
+    This research used data from the Seshat Databank (https://seshat-db.com) under the Creative Commons Attribution–ShareAlike 4.0 International License (CC BY-SA 4.0): https://creativecommons.org/licenses/by-sa/4.0/.
+  </blockquote>
+
+  <p><strong>Reference (example):</strong></p>
+  <ul>
+    <li>
+      Benam, M. et al. (2022). <em>Seshat Data: Equinox Packaged Data (1.0)</em> [Data set]. Zenodo.
+      <a href="https://doi.org/10.5281/zenodo.6642229">https://doi.org/10.5281/zenodo.6642229</a><br>
+      (For replication datasets tied to articles, see <a href="https://seshat-db.com/downloads_page/">https://seshat-db.com/downloads_page/</a>.)
+    </li>
+  </ul>
+
+  <h5>7) API Access</h5>
+  <ul>
+    <li><strong>Agreement applies:</strong> Use of any programmatic endpoints constitutes acceptance of the Current Terms.</li>
+    <li><strong>Authentication:</strong> We may require API tokens and verified accounts; only users who have accepted the Current Terms will receive/retain access.</li>
+    <li><strong>Rate limits &amp; suspension:</strong> We may limit, suspend, or revoke API access to protect the service or enforce this Agreement.</li>
+  </ul>
+
+  <h5>8) Prohibited Uses</h5>
+  <ul>
+    <li>Share, publish, or redistribute <strong>Private Data</strong>.</li>
+    <li>Use Public Data without complying with the <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license">CC BY-SA 4.0 license terms</a>.</li>
+    <li>Remove or obscure attribution/license notices.</li>
+    <li>Misrepresent Seshat data, or attempt to re-identify sensitive information contrary to ethical guidelines.</li>
+  </ul>
+
+  <h5>9) Accuracy &amp; Feedback</h5>
+  <p>Seshat strives for accuracy but provides data “as is.” We welcome corrections and sources via the private comment features where available.</p>
+
+  <h5>10) Attribution</h5>
+  <p>Whenever you use or refer to Seshat Public Data, you must provide clear attribution as outlined in Section 6.</p>
+
+  <h5>11) Changes to this Agreement</h5>
+  <p>We may update these terms. <strong>Material changes</strong> will require <strong>re-consent</strong> on your next visit before you can continue or download.</p>
+</div>
+""".strip()
+
+
+def publish_cc_by_sa_agreement(apps, schema_editor):
+    TermsVersion = apps.get_model("accounts", "TermsVersion")
+
+    TermsVersion.objects.filter(is_active=True).exclude(slug=AGREEMENT_SLUG).update(
+        is_active=False
+    )
+    TermsVersion.objects.update_or_create(
+        slug=AGREEMENT_SLUG,
+        defaults={
+            "title": AGREEMENT_TITLE,
+            "body_html": AGREEMENT_BODY_HTML,
+            "is_active": True,
+        },
+    )
+
+
+def restore_previous_agreement(apps, schema_editor):
+    TermsVersion = apps.get_model("accounts", "TermsVersion")
+
+    TermsVersion.objects.filter(slug=AGREEMENT_SLUG).update(is_active=False)
+    previous = (
+        TermsVersion.objects.exclude(slug=AGREEMENT_SLUG)
+        .order_by("-published_at")
+        .first()
+    )
+    if previous:
+        previous.is_active = True
+        previous.save(update_fields=["is_active"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts", "0016_termsversion_termsacceptance"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            publish_cc_by_sa_agreement,
+            reverse_code=restore_previous_agreement,
+        ),
+    ]

--- a/seshat/apps/core/middleware.py
+++ b/seshat/apps/core/middleware.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model, login
 from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse, resolve, Resolver404
+
 from .terms_utils import user_has_accepted_latest_terms
 
 class AutoLoginMiddleware:
@@ -30,7 +31,12 @@ class AutoLoginMiddleware:
 # core/middleware.py
 
 EXEMPT_PREFIXES = ('/admin/', '/static/', '/media/')
-EXEMPT_VIEWNAMES = {'terms_current', 'terms_accept', 'account_login', 'account_logout'}
+EXEMPT_VIEWNAMES = {
+    'terms_current',
+    'terms_accept',
+    'account_login',
+    'account_logout',
+}
 
 class EnforceLatestTermsMiddleware:
     def __init__(self, get_response):
@@ -47,7 +53,8 @@ class EnforceLatestTermsMiddleware:
         if not (user and user.is_authenticated):
             return self.get_response(request)
 
-        # Already accepted → clear any stale flags and continue
+        # Acceptance is recorded per TermsVersion, so accepting an older version
+        # does not satisfy the currently active agreement.
         if user_has_accepted_latest_terms(user):
             request.session.pop('FORCE_TERMS_MODAL', None)
             request.session.pop('TERMS_MODAL_SHOWN', None)
@@ -61,14 +68,14 @@ class EnforceLatestTermsMiddleware:
         if view_name in EXEMPT_VIEWNAMES:
             return self.get_response(request)
 
-        # 🔑 First non-exempt hit this session → arm one-shot modal
+        # The original workflow shows the active agreement in a modal on the
+        # requested page. The context processor consumes this one-shot flag.
         request.session['FORCE_TERMS_MODAL'] = True
 
-        if "download" in path:
-            if user and user.is_authenticated:
-                if not user_has_accepted_latest_terms(user):
-                    return redirect(reverse("seshat-index"))
-
+        # Downloads cannot render the modal, so return to the homepage where it
+        # will be shown before the user can retry the download.
+        if 'download' in path:
+            return redirect(reverse('seshat-index'))
 
         return self.get_response(request)
 

--- a/seshat/apps/core/templates/core/partials/_footer_bar.html
+++ b/seshat/apps/core/templates/core/partials/_footer_bar.html
@@ -1,7 +1,9 @@
     <footer id="main-footer" class="py-2 dijamm text-center navbar-brown text-light">
         <span>
             Copyright ©
-            <span class="year">2024</span>, <b>Seshat: Global History Databank</b>.
+            <span class="year">{% now "Y" %}</span>, <b>Seshat: Global History Databank</b>.
+            &nbsp;|&nbsp;
+            <a href="{% url 'terms_current' %}" class="text-light text-decoration-underline">User Agreement &amp; Data License</a>
         </span>
         <div class="text-center fw-bold">
             Stay in touch with us: &nbsp;

--- a/seshat/apps/core/templates/core/partials/_terms_modal.html
+++ b/seshat/apps/core/templates/core/partials/_terms_modal.html
@@ -1,0 +1,32 @@
+{% if TERMS_SHOW_MODAL and TERMS_CURRENT %}
+  <div class="modal fade" id="termsModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ TERMS_CURRENT.title }}</h5>
+        </div>
+        <div class="modal-body">
+          {{ TERMS_CURRENT.body_html|safe }}
+        </div>
+        <div class="modal-footer">
+          <form id="terms-accept-form" method="post" action="{% url 'terms_accept' %}">
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ request.get_full_path }}">
+            <button type="submit" class="btn btn-success">I Agree</button>
+          </form>
+          <a href="{% url 'account_logout' %}" class="btn btn-outline-secondary">Sign out</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', function(){
+    var modalEl = document.getElementById('termsModal');
+    if (modalEl) {
+      var modal = new bootstrap.Modal(modalEl, {backdrop:'static', keyboard:false});
+      modal.show();
+    }
+  });
+  </script>
+{% endif %}

--- a/seshat/apps/core/templates/core/seshat-base-for-home.html
+++ b/seshat/apps/core/templates/core/seshat-base-for-home.html
@@ -108,6 +108,7 @@
     {% block content-home %} {% endblock %}
   </div>
 
+    {% include "core/partials/_terms_modal.html" %}
 
     <!-- footer -->
       {% include "core/partials/_footer_bar.html" %}

--- a/seshat/apps/core/templates/core/seshat-base.html
+++ b/seshat/apps/core/templates/core/seshat-base.html
@@ -114,39 +114,7 @@
     {% block content-home %} {% endblock %}
   </div>
 
-  {% if TERMS_SHOW_MODAL and TERMS_CURRENT %}
-  <div class="modal fade" id="termsModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">{{ TERMS_CURRENT.title }}</h5>
-        </div>
-        <div class="modal-body">
-          <!-- If you store HTML in body_html -->
-          {{ TERMS_CURRENT.body_html|safe }}
-        </div>
-        <div class="modal-footer">
-          <form id="terms-accept-form" method="post" action="{% url 'terms_accept' %}">
-            {% csrf_token %}
-            <input type="hidden" name="next" value="{{ request.get_full_path }}">
-            <button type="submit" class="btn btn-success">I Agree</button>
-          </form>
-          <a href="{% url 'seshat-index' %}" class="btn btn-outline-secondary">Cancel</a>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <script>
-  document.addEventListener('DOMContentLoaded', function(){
-    var modalEl = document.getElementById('termsModal');
-    if (modalEl) {
-      var modal = new bootstrap.Modal(modalEl, {backdrop:'static', keyboard:false});
-      modal.show();
-    }
-  });
-  </script>
-{% endif %}
+  {% include "core/partials/_terms_modal.html" %}
 
     <!-- footer -->
       {% include "core/partials/_footer_bar.html" %}

--- a/seshat/apps/core/templates/core/terms.html
+++ b/seshat/apps/core/templates/core/terms.html
@@ -7,29 +7,26 @@
     <div>
         {{terms.body_html|safe}}
     </div>
-  {% if false %}
-
-        <div class="modal-footer">
-            {% if TERMS_ALREADY_ACCEPTED %}
-                <div class="text-start me-auto">
+    <div class="d-flex align-items-center border-top mt-3 pt-3">
+        {% if TERMS_ALREADY_ACCEPTED %}
+            <div class="text-start me-auto">
                 <div class="alert alert-success mb-0" role="alert">
-                    You’ve already accepted <strong>{{ TERMS_CURRENT.title }}</strong>
+                    You’ve already accepted <strong>{{ terms.title }}</strong>
                     {% if TERMS_ACCEPTED_AT %} on {{ TERMS_ACCEPTED_AT|date:"Y-m-d" }}{% endif %}.
                 </div>
-                </div>
-                <a href="{% url 'seshat-index' %}" class="btn btn-primary">
-                Home
-                </a>
-            {% else %}
-                <form id="terms-accept-form" method="post" action="{% url 'terms_accept' %}">
+            </div>
+            <a href="{{ next|default:'/' }}" class="btn btn-primary">Continue</a>
+        {% elif user.is_authenticated %}
+            <form id="terms-accept-form" method="post" action="{% url 'terms_accept' %}">
                 {% csrf_token %}
-                <input type="hidden" name="next" value="{{ my_caller|default:request.get_full_path }}">
+                <input type="hidden" name="next" value="{{ next|default:'/' }}">
                 <button type="submit" class="btn btn-success">I Agree</button>
-                </form>
-                <a href="{% url 'seshat-index' %}" class="btn btn-outline-secondary">Cancel</a>
-            {% endif %}
-        </div>
-{% endif %}
+            </form>
+            <a href="{% url 'account_logout' %}" class="btn btn-outline-secondary ms-2">Sign out</a>
+        {% else %}
+            <a href="{% url 'seshat-index' %}" class="btn btn-primary ms-auto">Home</a>
+        {% endif %}
+    </div>
 
 </div>
 

--- a/seshat/apps/core/tests/test_terms_acceptance.py
+++ b/seshat/apps/core/tests/test_terms_acceptance.py
@@ -1,0 +1,102 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from seshat.apps.accounts.models import TermsAcceptance, TermsVersion
+
+
+class TermsAcceptanceFlowTests(TestCase):
+    def setUp(self):
+        TermsVersion.objects.update(is_active=False)
+        self.old_terms = TermsVersion.objects.create(
+            slug="old-terms",
+            title="Old terms",
+            body_html="<p>Old terms</p>",
+            is_active=False,
+        )
+        self.current_terms = TermsVersion.objects.create(
+            slug="current-terms",
+            title="Current terms",
+            body_html="<p>Current terms</p>",
+            is_active=True,
+        )
+        self.user = get_user_model().objects.create_user(
+            username="terms-user",
+            password="test-password",
+        )
+        self.client.force_login(self.user)
+
+    def test_old_acceptance_does_not_satisfy_current_terms(self):
+        TermsAcceptance.objects.create(user=self.user, terms=self.old_terms)
+
+        response = self.client.get(reverse("seshat-index"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="termsModal"')
+        self.assertContains(response, "Current terms")
+        self.assertContains(response, "I Agree")
+
+    def test_user_accepts_current_terms_only_once(self):
+        agreement_page = self.client.get(reverse("terms_current"))
+        self.assertContains(agreement_page, "Current terms")
+        self.assertContains(agreement_page, "I Agree")
+
+        response = self.client.post(
+            reverse("terms_accept"),
+            {"next": reverse("seshat-methods")},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("seshat-methods"),
+            fetch_redirect_response=False,
+        )
+        self.assertEqual(
+            TermsAcceptance.objects.filter(
+                user=self.user,
+                terms=self.current_terms,
+            ).count(),
+            1,
+        )
+
+        self.client.post(reverse("terms_accept"), {"next": "/"})
+        self.assertEqual(
+            TermsAcceptance.objects.filter(
+                user=self.user,
+                terms=self.current_terms,
+            ).count(),
+            1,
+        )
+
+    def test_current_acceptance_allows_site_access(self):
+        TermsAcceptance.objects.create(user=self.user, terms=self.current_terms)
+
+        response = self.client.get(reverse("seshat-methods"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="termsModal"')
+
+    def test_public_api_access_remains_unchanged(self):
+        response = self.client.get("/api/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="termsModal"')
+
+    def test_download_redirects_to_homepage_modal_until_terms_are_accepted(self):
+        response = self.client.get(reverse("seshat-olddownloads"))
+
+        self.assertRedirects(
+            response,
+            reverse("seshat-index"),
+            fetch_redirect_response=False,
+        )
+        homepage = self.client.get(reverse("seshat-index"))
+        self.assertContains(homepage, 'id="termsModal"')
+
+    def test_external_next_url_is_rejected(self):
+        response = self.client.post(
+            reverse("terms_accept"),
+            {"next": "https://example.com/phishing"},
+        )
+
+        self.assertRedirects(response, "/", fetch_redirect_response=False)

--- a/seshat/apps/core/views.py
+++ b/seshat/apps/core/views.py
@@ -19,7 +19,7 @@ from django.contrib.auth import login, authenticate
 from django.shortcuts import render
 from django.http import HttpResponse, Http404
 from django.utils.encoding import force_bytes, force_str
-from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.http import url_has_allowed_host_and_scheme, urlsafe_base64_encode, urlsafe_base64_decode
 from django.template.loader import render_to_string
 from .tokens import account_activation_token
 from django.contrib.auth.models import User, Group, Permission
@@ -7053,12 +7053,9 @@ def terms_current(request):
             accepted_at = qs.first().accepted_at
 
     next_url = request.GET.get("next") or "/"
-    my_caller = request.META.get("HTTP_REFERER")
-
     return render(request, "core/terms.html", {
         "terms": current, 
         "next": next_url,
-        'my_caller': my_caller,
         "TERMS_ALREADY_ACCEPTED": already_accepted,
         "TERMS_ACCEPTED_AT": accepted_at,})
 
@@ -7084,7 +7081,14 @@ def terms_accept(request):
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:1000],
             }
         )
-        return redirect(request.POST.get("next") or "/")
+        next_url = request.POST.get("next") or "/"
+        if not url_has_allowed_host_and_scheme(
+            next_url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            next_url = "/"
+        return redirect(next_url)
     #return redirect(f"{reverse('terms_launch')}?next={quote(request.get_full_path())}")
 
     return redirect(reverse("seshat-index"))

--- a/seshat/apps/crisisdb/tests/test_manual_instability_create.py
+++ b/seshat/apps/crisisdb/tests/test_manual_instability_create.py
@@ -6,7 +6,11 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 
-from seshat.apps.accounts.models import Seshat_Expert
+from seshat.apps.accounts.models import (
+    Seshat_Expert,
+    TermsAcceptance,
+    TermsVersion,
+)
 from seshat.apps.core.models import Polity, SeshatComment
 from seshat.apps.crisisdb.instability_filters import (
     GOOD_ROW_FILTER,
@@ -35,6 +39,9 @@ class InstabilityCreateViewTests(TestCase):
             Permission.objects.get(codename="add_seshatprivatecommentpart")
         )
         Seshat_Expert.objects.create(user=user, role=Seshat_Expert.RA)
+        current_terms = TermsVersion.objects.filter(is_active=True).first()
+        if current_terms:
+            TermsAcceptance.objects.create(user=user, terms=current_terms)
         self.user = user
         self.client.force_login(user)
 

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -181,6 +181,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "seshat.apps.core.middleware.EnforceLatestTermsMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -205,6 +206,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "seshat.apps.core.context_processors.terms_banner",
                 "seshat.apps.core.context_processors.notifications",  # Add your context processor
             ],
         },

--- a/seshat/settings/local.py
+++ b/seshat/settings/local.py
@@ -25,6 +25,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "seshat.apps.core.middleware.EnforceLatestTermsMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",


### PR DESCRIPTION
## Summary

- publish a new version of the Seshat User Agreement using the Creative Commons Attribution–ShareAlike 4.0 International license
- preserve the previous agreement and its historical acceptance records
- prompt existing registered users to accept the new active agreement once
- complete the existing modal-based acceptance workflow on normal pages and the homepage
- keep new-user acceptance integrated with registration
- add a permanent User Agreement & Data License link to the footer
- make the footer copyright year update dynamically

## Database migration

This PR adds migration `accounts.0017_publish_cc_by_sa_4_terms`.

The migration:

- deactivates the previous agreement without deleting it
- publishes the CC BY-SA 4.0 agreement as the active version
- preserves all existing acceptance records

Run after deployment:

```bash
python3 manage.py migrate